### PR TITLE
Replaced excess EtnaFollower instance creation

### DIFF
--- a/classes/classes/Scenes/Areas/Beach.as
+++ b/classes/classes/Scenes/Areas/Beach.as
@@ -12,9 +12,7 @@ package classes.Scenes.Areas
 	import classes.Scenes.Areas.Beach.*;
 	import classes.Scenes.NPCs.CeaniScene;
 	//import classes.Scenes.NPCs.CaiLin;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
-	
+
 	use namespace kGAMECLASS;
 	
 	public class Beach extends BaseContent 
@@ -23,8 +21,7 @@ package classes.Scenes.Areas
 		public var demonsPack:DemonPackBeachScene = new DemonPackBeachScene();
 		public var pinchoushop:PinchousWaterwearAndTools = new PinchousWaterwearAndTools();
 		//public var gorgonScene:GorgonScene = new GorgonScene();przenieść do deep desert potem
-		public var etnaScene:EtnaFollower = new EtnaFollower();
-		
+
 		public function Beach() 
 		{
 		}
@@ -39,7 +36,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			

--- a/classes/classes/Scenes/Areas/Bog.as
+++ b/classes/classes/Scenes/Areas/Bog.as
@@ -6,15 +6,7 @@ package classes.Scenes.Areas
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
-	import classes.Items.ConsumableLib;
-	import classes.Items.Consumables.BeeHoney;
-	import classes.Items.Consumables.PhoukaWhiskey;
-	import classes.Items.Consumables.RizzaRoot;
 	import classes.Scenes.Areas.Bog.*;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
-
-	use namespace kGAMECLASS;
 
 	public class Bog extends BaseContent
 	{
@@ -22,7 +14,6 @@ package classes.Scenes.Areas
 		public var chameleonGirlScene:ChameleonGirlScene = new ChameleonGirlScene();
 		public var phoukaScene:PhoukaScene = new PhoukaScene();
 		public var lizanScene:LizanRogueScene = new LizanRogueScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public function Bog()
 		{
 		}
@@ -40,7 +31,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			if ((isHalloween() && (date.fullYear > flags[kFLAGS.TREACLE_MINE_YEAR_DONE]) && flags[kFLAGS.BOG_EXPLORED] % 4 == 0) && (flags[kFLAGS.PHOUKA_LORE] > 0)) {

--- a/classes/classes/Scenes/Areas/Desert.as
+++ b/classes/classes/Scenes/Areas/Desert.as
@@ -10,8 +10,6 @@ package classes.Scenes.Areas
 	import classes.Scenes.API.Encounters;
 	import classes.Scenes.API.FnHelpers;
 	import classes.Scenes.Areas.Desert.*;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 
 	use namespace kGAMECLASS;
 
@@ -23,7 +21,6 @@ package classes.Scenes.Areas
 		public var sandTrapScene:SandTrapScene = new SandTrapScene();
 		public var sandWitchScene:SandWitchScene = new SandWitchScene();
 		public var wanderer:Wanderer = new Wanderer();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public function Desert()
 		{
 		}
@@ -146,7 +143,7 @@ package classes.Scenes.Areas
 						{
 							return (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2);
 						},
-						call: etnaScene.repeatYandereEnc
+						call: game.etnaScene.repeatYandereEnc
 					}, {
 						//Helia monogamy fucks
 						name  : "helcommon",

--- a/classes/classes/Scenes/Areas/Forest.as
+++ b/classes/classes/Scenes/Areas/Forest.as
@@ -6,12 +6,10 @@ package classes.Scenes.Areas
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
-	import classes.GlobalFlags.kACHIEVEMENTS;
 	import classes.Scenes.API.Encounter;
 	import classes.Scenes.API.Encounters;
 	import classes.Scenes.API.FnHelpers;
 	import classes.Scenes.Areas.Forest.*;
-	import classes.Scenes.NPCs.EtnaFollower;
 	import classes.Scenes.Monsters.DarkElfScene;
 
 	use namespace kGAMECLASS;
@@ -28,7 +26,6 @@ package classes.Scenes.Areas
 		public var tamaniScene:TamaniScene = new TamaniScene();
 		public var tentacleBeastScene:TentacleBeastScene = new TentacleBeastScene();
 		public var erlkingScene:ErlKingScene = new ErlKingScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public var alrauneScene:AlrauneScene = new AlrauneScene();
 		public var darkelfScene:DarkElfScene = new DarkElfScene();
 		// public var dullahanScene:DullahanScene = new DullahanScene(); // [INTERMOD:8chan]
@@ -228,7 +225,7 @@ package classes.Scenes.Areas
 					return flags[kFLAGS.ETNA_FOLLOWER] < 1
 						   && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2;
 				},
-				call  : etnaScene.repeatYandereEnc
+				call  : kGAMECLASS.etnaScene.repeatYandereEnc
 			}, {
 				name: "kitsune",
 				when: function():Boolean {

--- a/classes/classes/Scenes/Areas/GlacialRift.as
+++ b/classes/classes/Scenes/Areas/GlacialRift.as
@@ -17,9 +17,6 @@ package classes.Scenes.Areas
 	import classes.Scenes.Areas.GlacialRift.*;
 	import classes.Scenes.Areas.Forest.AlrauneScene;
 	import classes.Scenes.NPCs.GooArmor;
-	import classes.Player;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 
 	use namespace kGAMECLASS;
 	
@@ -29,7 +26,6 @@ package classes.Scenes.Areas
 		public var yetiScene:YetiScene = new YetiScene();
 		public var giantScene:FrostGiantScene = new FrostGiantScene();
 		public var winterwolfScene:WinterWolfScene = new WinterWolfScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public var alrauneScene:AlrauneScene = new AlrauneScene();
 		
 		public function GlacialRift() 
@@ -68,7 +64,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			select = choice[rand(choice.length)];

--- a/classes/classes/Scenes/Areas/HighMountains.as
+++ b/classes/classes/Scenes/Areas/HighMountains.as
@@ -7,8 +7,6 @@ package classes.Scenes.Areas
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.Areas.HighMountains.*;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 	import classes.Scenes.Monsters.DarkElfScene;
 
 	use namespace kGAMECLASS;
@@ -21,7 +19,6 @@ package classes.Scenes.Areas
 		public var minotaurMobScene:MinotaurMobScene = new MinotaurMobScene();
 		public var izumiScenes:IzumiScene = new IzumiScene();
 		public var phoenixScene:PhoenixScene = new PhoenixScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public var templeofdivine:TempleOfTheDivine = new TempleOfTheDivine();
 		public var darkelfScene:DarkElfScene = new DarkElfScene();
 		
@@ -65,8 +62,8 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && rand(3) == 0 && player.level >= 25) {
-				if (flags[kFLAGS.ETNA_AFFECTION] < 5) etnaScene.firstEnc();
-				else etnaScene.repeatEnc();
+				if (flags[kFLAGS.ETNA_AFFECTION] < 5) kGAMECLASS.etnaScene.firstEnc();
+				else kGAMECLASS.etnaScene.repeatEnc();
 				return;
 			}
 			//Temple of the Divine

--- a/classes/classes/Scenes/Areas/Lake.as
+++ b/classes/classes/Scenes/Areas/Lake.as
@@ -7,8 +7,6 @@ package classes.Scenes.Areas
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.Areas.Lake.*;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 
 	use namespace kGAMECLASS;
 
@@ -22,7 +20,6 @@ package classes.Scenes.Areas
 		public var kaiju:Kaiju = new Kaiju();
 		public var calluScene:CalluScene = new CalluScene();
 		public var swordInStone:SwordInStone = new SwordInStone();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public function Lake()
 		{
 		}
@@ -40,7 +37,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			if (player.exploredLake % 20 == 0) {

--- a/classes/classes/Scenes/Areas/Mountain.as
+++ b/classes/classes/Scenes/Areas/Mountain.as
@@ -8,13 +8,7 @@ package classes.Scenes.Areas
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.Areas.Mountain.*;
 	import classes.Scenes.Monsters.DarkElfScene;
-	import classes.Scenes.Monsters.Goblin;
-	import classes.Scenes.Monsters.Imp;
 	import classes.Scenes.Quests.UrtaQuest.MinotaurLord;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
-
-	use namespace kGAMECLASS;
 
 	public class Mountain extends BaseContent
 	{
@@ -23,7 +17,6 @@ package classes.Scenes.Areas
 		public var minotaurScene:MinotaurScene = new MinotaurScene();
 		public var wormsScene:WormsScene = new WormsScene();
 		public var salon:Salon = new Salon();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public var darkelfScene:DarkElfScene = new DarkElfScene();
 		
 		public function Mountain()
@@ -41,7 +34,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			//Discover 'high mountain' at level 5 or 40 explores of mountain

--- a/classes/classes/Scenes/Areas/Plains.as
+++ b/classes/classes/Scenes/Areas/Plains.as
@@ -7,8 +7,6 @@ package classes.Scenes.Areas
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.Areas.Plains.*;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 
 	use namespace kGAMECLASS;
 
@@ -18,7 +16,6 @@ package classes.Scenes.Areas
 		public var gnollScene:GnollScene = new GnollScene();
 		public var gnollSpearThrowerScene:GnollSpearThrowerScene = new GnollSpearThrowerScene();
 		public var satyrScene:SatyrScene = new SatyrScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 
 		public function Plains()
 		{
@@ -49,7 +46,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			//Find Niamh

--- a/classes/classes/Scenes/Areas/Swamp.as
+++ b/classes/classes/Scenes/Areas/Swamp.as
@@ -7,8 +7,6 @@ package classes.Scenes.Areas
 	import classes.GlobalFlags.kFLAGS;
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.Areas.Swamp.*;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 
 	use namespace kGAMECLASS;
 
@@ -18,7 +16,6 @@ package classes.Scenes.Areas
 		public var femaleSpiderMorphScene:FemaleSpiderMorphScene = new FemaleSpiderMorphScene();
 		public var maleSpiderMorphScene:MaleSpiderMorphScene = new MaleSpiderMorphScene();
 		public var rogar:Rogar = new Rogar();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public function Swamp()
 		{
 		}
@@ -46,7 +43,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			if (flags[kFLAGS.TOOK_EMBER_EGG] == 0 && flags[kFLAGS.EGG_BROKEN] == 0 && flags[kFLAGS.TIMES_EXPLORED_SWAMP] > 0 && (flags[kFLAGS.TIMES_EXPLORED_SWAMP] % 40 == 0)) {

--- a/classes/classes/Scenes/Areas/VolcanicCrag.as
+++ b/classes/classes/Scenes/Areas/VolcanicCrag.as
@@ -13,16 +13,11 @@ package classes.Scenes.Areas
 	import classes.Scenes.Areas.VolcanicCrag.*;
 	import classes.Scenes.Areas.HighMountains.PhoenixScene;
 	import classes.Scenes.Areas.Forest.AlrauneScene;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
-	
-	use namespace kGAMECLASS;
-	
+
 	public class VolcanicCrag extends BaseContent
 	{
 		public var behemothScene:BehemothScene = new BehemothScene();
 		public var phoenixScene:PhoenixScene = new PhoenixScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public var alrauneScene:AlrauneScene = new AlrauneScene();
 		
 		public function VolcanicCrag() 
@@ -30,7 +25,7 @@ package classes.Scenes.Areas
 		}
 		
 		public function exploreVolcanicCrag():void {
-			flags[kFLAGS.DISCOVERED_VOLCANO_CRAG]++
+			flags[kFLAGS.DISCOVERED_VOLCANO_CRAG]++;
 			doNext(playerMenu);
 
 			var choice:Array = [];
@@ -56,7 +51,7 @@ package classes.Scenes.Areas
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			select = choice[rand(choice.length)];
@@ -87,6 +82,7 @@ package classes.Scenes.Areas
 					} else {
 						alrauneScene.alrauneVolcanicCrag();
 					}
+					break;
 				default:
 					clearOutput();
 					outputText("You spend one hour exploring the infernal landscape but you don't manage to find anything interesting, yet you this time you managed walk a little further inside this place than the last time.");

--- a/classes/classes/Scenes/Camp.as
+++ b/classes/classes/Scenes/Camp.as
@@ -64,7 +64,6 @@
 		public var dungeonHC:HiddenCave = new HiddenCave();
 		public var EvangelineF:EvangelineFollower = new EvangelineFollower();
 		public var HolliPure:HolliPureScene = new HolliPureScene();
-		public var EtnaF:EtnaFollower = new EtnaFollower();
 		public var templeofdivine:TempleOfTheDivine = new TempleOfTheDivine();
 		
 /* Replaced with calls to playerMenu
@@ -1016,7 +1015,7 @@ public function campLoversMenu(descOnly:Boolean = false):void {
 	//Etna
 	if (flags[kFLAGS.ETNA_FOLLOWER] > 0) {
 		outputText("Etna is resting lazily on a rug in a very cat-like manner. She’s looking at you always with this adorable expression of hers, her tail wagging expectantly at your approach.\n\n");
-		addButton(3, "Etna", EtnaF.etnaCampMenu);
+		addButton(3, "Etna", kGAMECLASS.etnaScene.etnaCampMenu);
 	}
 	//Helia
 	if(kGAMECLASS.helScene.followerHel()) {
@@ -1512,7 +1511,7 @@ public function spellHealcamp():void {
 	//30% backfire!
 	var backfire:int = 30;
 	if (player.findPerk(PerkLib.FocusedMind) >= 0) backfire = 20;
-	backfire -= (player.inte * 0,15);
+	backfire -= (player.inte * 0.15);
 	if (backfire < 15) backfire = 15;
 	else if (backfire < 5 && player.findPerk(PerkLib.FocusedMind) >= 0) backfire = 5;
 	if(rand(100) < backfire) {

--- a/classes/classes/Scenes/Monsters/ImpOverlord.as
+++ b/classes/classes/Scenes/Monsters/ImpOverlord.as
@@ -2,10 +2,8 @@ package classes.Scenes.Monsters
 {
 	import classes.*;
 	import classes.internals.*;
-	import classes.GlobalFlags.kGAMECLASS;
 	import classes.GlobalFlags.kFLAGS;
-	import classes.Scenes.NPCs.EtnaFollower;
-	
+
 	public class ImpOverlord extends Imp
 	{
 		public var spellCostCharge:int = 6;

--- a/classes/classes/Scenes/Monsters/ImpWarlord.as
+++ b/classes/classes/Scenes/Monsters/ImpWarlord.as
@@ -2,10 +2,8 @@ package classes.Scenes.Monsters
 {
 	import classes.*;
 	import classes.internals.*;
-	import classes.GlobalFlags.kGAMECLASS;
 	import classes.GlobalFlags.kFLAGS;
-	import classes.Scenes.NPCs.EtnaFollower;
-	
+
 	public class ImpWarlord extends Imp
 	{
 		public function clawAttack():void {

--- a/classes/classes/Scenes/NPCs/Etna.as
+++ b/classes/classes/Scenes/NPCs/Etna.as
@@ -13,8 +13,8 @@ package classes.Scenes.NPCs
 	
 	public class Etna extends Monster 
 	{
-		public var etnaScene:EtnaFollower = new EtnaFollower();
-		
+		public var etnaScene:EtnaFollower = game.etnaScene;
+
 		public function moveClawCombo():void {
 			createStatusEffect(StatusEffects.Attacks,2,0,0,0);
 			eAttack();

--- a/classes/classes/Scenes/Places/Boat.as
+++ b/classes/classes/Scenes/Places/Boat.as
@@ -8,15 +8,11 @@ package classes.Scenes.Places
 	import classes.GlobalFlags.kGAMECLASS;
 	import classes.Scenes.Areas.Lake.*;
 	import classes.Scenes.Places.Boat.*;
-	import classes.Player;
-	import classes.Scenes.NPCs.Etna;
-	import classes.Scenes.NPCs.EtnaFollower;
 
 	public class Boat extends AbstractLakeContent
 	{
 		public var sharkGirlScene:SharkGirlScene = new SharkGirlScene();
 		public var marae:MaraeScene = new MaraeScene();
-		public var etnaScene:EtnaFollower = new EtnaFollower();
 		public function Boat()
 		{
 		}
@@ -39,7 +35,7 @@ package classes.Scenes.Places
 			}
 			//Etna
 			if (flags[kFLAGS.ETNA_FOLLOWER] < 1 && flags[kFLAGS.ETNA_TALKED_ABOUT_HER] == 2 && rand(5) == 0) {
-				etnaScene.repeatYandereEnc();
+				kGAMECLASS.etnaScene.repeatYandereEnc();
 				return;
 			}
 			clearOutput();


### PR DESCRIPTION
@Ormael7 avoid creating multiple scene instances. Some of them register themselves as TimeAwareInterface and it can cause duplicate events.
All scenes should be reachable from kGAMECLASS, and that's enough