### PR TITLE
Add option to use old CharView position

### DIFF
--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -390,6 +390,12 @@ addButton(14, "Back", CoC.instance.mainMenu.mainMenu);
 		outputText("Char Viewer: ");
 		if (flags[kFLAGS.CHARVIEWER_ENABLED] == 1) outputText("<font color=\"#008000\"><b>ON</b></font>\n Player visualiser is available under \\[Appearance\\].");
 		else outputText("<font color=\"#800000\"><b>OFF</b></font>\n Player visualiser is disabled.");
+		outputText("\nChar View Style: ");
+		if (flags[kFLAGS.CHARVIEW_STYLE] < 1){
+			outputText("<font color=\"#008000\"><b>NEW</b></font>\n Viewer is inline with text");
+		} else {
+			outputText("<font color=\"#800000\"><b>OLD</b></font>\n Viewer is separate from text");
+		}
 		outputText("\n\n");
 
 		if (flags[kFLAGS.IMAGEPACK_OFF] == 0) {
@@ -437,6 +443,7 @@ addButton(14, "Back", CoC.instance.mainMenu.mainMenu);
 		addButton(6, "Time Format", toggleTimeFormat).hint("Toggles between 12-hour and 24-hour format.");
 		addButton(7, "Measurements", toggleMeasurements).hint("Switch between imperial and metric measurements.  \n\nNOTE: Only applies to your appearance screen.");
 		addButton(8, "Toggle CharView", toggleCharViewer).hint("Turn PC visualizer on/off.");
+		addButton(9, "Charview Style",toggleCharViewer,kFLAGS.CHARVIEW_STYLE).hint("Change between in text and sidebar display");
 		addButton(14, "Back", settingsScreenMain);
 	}
 	public function menuMainBackground():void {
@@ -468,11 +475,13 @@ addButton(14, "Back", CoC.instance.mainMenu.mainMenu);
 		addButton(14, "Back", settingsScreenInterfaceSettings);
 	}
 
-	public function toggleCharViewer():void {
-		if (flags[kFLAGS.CHARVIEWER_ENABLED] < 1) {
-			flags[kFLAGS.CHARVIEWER_ENABLED] = 1;
+	public function toggleCharViewer(flag:int = kFLAGS.CHARVIEWER_ENABLED):void {
+		if (flags[flag] < 1) {
+			flags[flag] = 1;
 			mainView.charView.reload();
-		} else flags[kFLAGS.CHARVIEWER_ENABLED] = 0;
+		} else {
+			flags[flag] = 0;
+		}
 		settingsScreenInterfaceSettings();
 	}
 

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2982,7 +2982,7 @@ public static const UNKNOWN_FLAG_NUMBER_02973:int                               
 public static const SPARRABLE_NPCS_TRAINING:int                                     = 2974;
 public static const STAT_GAIN_MODE:int                                              = 2975;
 public static const UNKNOWN_FLAG_NUMBER_02976:int                                   = 2976;
-public static const UNKNOWN_FLAG_NUMBER_02977:int                                   = 2977;
+public static const CHARVIEW_STYLE:int                                              = 2977; // 0 for in text, 1 for sidebar
 public static const CHARVIEWER_ENABLED:int                                          = 2978;
 public static const NEW_GAME_PLUS_LEVEL:int                                         = 2979; // Current intensity of New Game+. Each ascension increments this counter by 1.
 public static const NEW_GAME_PLUS_BONUS_UNLOCKED_HERM:int                           = 2980; // Unlocked hermaphrodite.

--- a/classes/classes/MainViewManager.as
+++ b/classes/classes/MainViewManager.as
@@ -94,8 +94,16 @@ public class MainViewManager extends BaseContent {
 		mainView.charView.setCharacter(player);
 		mainView.charView.redraw();
 		mainView.charView.visible = true;
-		BoundClip.nextContent = mainView.charView;
-		outputText("<img src='coc.view::BoundClip' align='left' id='charview'/>");
+		if(flags[kFLAGS.CHARVIEW_STYLE] < 1){
+			mainView.charView.x = 0;
+			mainView.charView.y = 0;
+			BoundClip.nextContent = mainView.charView;
+			outputText("<img src='coc.view::BoundClip' align='left' id='charview'/>");
+		} else {
+			mainView.charView.x = 208 + 796 + 4; //TEXTZONE_X + TEXTZONE_W + GAP
+			mainView.charView.y = 52; // TEXTZONE_Y;
+			mainView.addElement(mainView.charView);
+		}
 	}
 	public function hidePlayerDoll():void {
 		mainView.charView.visible = false;


### PR DESCRIPTION
This is a quick fix requested by Liadri for the character viewer not displaying on android builds. 

Adds a toggle to the interface settings menu, and uses the previously unused flag 2977