### PR TITLE
Fix for monster combat init error messages throwing incorrectly

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -797,14 +797,14 @@ public class Creature extends Utils
 				"balls", "ballSize", "cumMultiplier", "hoursSinceCum",
 				"tallness", "hips.type", "butt.type", "lowerBody", "arms.type",
 				"hairLength", "hairType",
-				"faceType", "earType", "tongue.type", "eyes.type",
+				"faceType", "ears.type", "tongue.type", "eyes.type",
 				"str", "tou", "spe", "inte", "wis", "lib", "sens", "cor",
 				// Allow weaponAttack to be negative as a penalty to strength-calculated damage
 				// Same with armorDef, bonusHP, additionalXP
 				"weaponValue", "armorValue",
 				"lust", "fatigue", "soulforce", "mana", "wrath",
 				"level", "gems",
-				"tailCount", "tailVenom", "tailRecharge", "_horns",
+				"tailCount", "tailVenom", "tailRecharge", "horns.type",
 				"HP", "XP"
 			]);
 			// 2.2. non-empty String fields

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -326,10 +326,18 @@ package classes.internals
 			return Math.random()*n < 1;
 		}
 
-		public static function validateNonNegativeNumberFields(o:Object, func:String, nnf:Array):String
+		public static function validateNonNegativeNumberFields(obj:Object, func:String, nnf:Array):String
 		{
 			var error:String = "";
+			var o:Object = obj;
 			for each (var field:String in nnf) {
+				var keys:Array = field.split('.');
+				if(keys.length > 1){
+					o = obj[keys[0]];
+					field = keys[1];
+				} else {
+					o = obj;
+				}
 				if (!o.hasOwnProperty(field) || !(o[field] is Number) && o[field] != null) error += "Misspelling in "+func+".nnf: '"+field+"'. ";
 				else if (o[field] == null) error += "Null '"+field+"'. ";
 				else if (o[field] < 0) error += "Negative '"+field+"'. ";
@@ -337,10 +345,18 @@ package classes.internals
 			return error;
 		}
 		
-		public static function validateNonEmptyStringFields(o:Object, func:String, nef:Array):String
+		public static function validateNonEmptyStringFields(obj:Object, func:String, nef:Array):String
 		{
 			var error:String = "";
+			var o:Object = obj;
 			for each (var field:String in nef) {
+				var keys:Array = field.split('.');
+				if(keys.length > 1){
+					o = obj[keys[0]];
+					field = keys[1];
+				} else {
+					o = obj;
+				}
 				if (!o.hasOwnProperty(field) || !(o[field] is String) && o[field] != null) error += "Misspelling in "+func+".nef: '"+field+"'. ";
 				else if (o[field] == null) error += "Null '"+field+"'. ";
 				else if (o[field] == "") error += "Empty '"+field+"'. ";


### PR DESCRIPTION
Though I'm wondering if these checks are really needed.
Default values and uints remove the need for many of these checks.