### PR TITLE
Discussion on Inventory management.

### DIFF
--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -668,7 +668,7 @@ public class GameSettings extends BaseContent {
 
 	}
 	public function toggleInvt():void {
-		if (flags[kFLAGS.INVT_MGMT_TYPE] < 0) flags[kFLAGS.INVT_MGMT_TYPE] = 0;
+		if (flags[kFLAGS.INVT_MGMT_TYPE] > 0) flags[kFLAGS.INVT_MGMT_TYPE] = 0;
 		else flags[kFLAGS.INVT_MGMT_TYPE] = 1;
 		settingsScreenInterfaceSettings();
 	}

--- a/classes/classes/GameSettings.as
+++ b/classes/classes/GameSettings.as
@@ -572,13 +572,19 @@ public class GameSettings extends BaseContent {
 			outputText("Measurement: <b>Metric</b>\n Height and cock size will be measured in metres and centimetres.");
 		else
 			outputText("Measurement: <b>Imperial</b>\n Height and cock size will be measured in feet and inches.");
+		outputText("\n\n");
+
+		if (flags[kFLAGS.INVT_MGMT_TYPE] > 0)
+			outputText("Inventory Mgmt: <b>New</b>\n A prompt will appear asking you what you want to do with the item.");
+		else
+			outputText("Inventory Mgmt: <b>Old</b>\n Shift key is required for removing items.");
 
 		menu();
 		addButton(0, "Side Bar Font", toggleFont).hint("Toggle between old and new font for side bar.");
 		addButton(1, "Main BG", menuMainBackground).hint("Choose a background for main game interface.");
 		addButton(2, "Text BG", menuTextBackground).hint("Choose a background for text.");
 		addButton(3, "Sprites", menuSpriteSelect).hint("Turn sprites on/off and change sprite style preference.");
-
+		addButton(4, "Inventory Mgmt", toggleInvt).hint("Toggle between existing SHIFT to remove items vs an extra menu. Recommended to enable for Mobile users.");
 		addButton(5, "Toggle Images", toggleImages).hint("Enable or disable image pack.");
 		addButton(6, "Time Format", toggleTimeFormat).hint("Toggles between 12-hour and 24-hour format.");
 		addButton(7, "Measurements", toggleMeasurements).hint("Switch between imperial and metric measurements.  \n\nNOTE: Only applies to your appearance screen.");
@@ -660,6 +666,11 @@ public class GameSettings extends BaseContent {
 		flags[kFLAGS.SPRITE_STYLE]      = style;
 		settingsScreenInterfaceSettings();
 
+	}
+	public function toggleInvt():void {
+		if (flags[kFLAGS.INVT_MGMT_TYPE] < 0) flags[kFLAGS.INVT_MGMT_TYPE] = 0;
+		else flags[kFLAGS.INVT_MGMT_TYPE] = 1;
+		settingsScreenInterfaceSettings();
 	}
 
 

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -2972,7 +2972,7 @@ public static const UNKNOWN_FLAG_NUMBER_02963:int                               
 public static const UNKNOWN_FLAG_NUMBER_02964:int                                   = 2964;
 public static const SECONDARY_STATS_SCALING:int                                     = 2965;
 public static const MELEE_DAMAGE_OVERHAUL:int                                   	= 2966;
-public static const UNKNOWN_FLAG_NUMBER_02967:int                                   = 2967;
+public static const INVT_MGMT_TYPE:int                                   			= 2967;//Toggles Inventory Management type between existing and new.
 public static const SPEED_SCALLING:int                                   			= 2968;
 public static const STRENGTH_SCALLING:int                                   		= 2969;
 public static const SPELLS_COOLDOWNS:int                                   			= 2970;

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -795,47 +795,51 @@ use namespace CoC;
 		/*
 		private function doWhatWithItem(slotNum:int):void { //Commented out due to players probably being used to spamming tfs. Alternative idea required. But the idea for this was an extra menu between use.
 			clearOutput();
-			//menu();
-			if (player.itemSlots[slotNum].itype is Useable) {
-				var item:Useable = player.itemSlots[slotNum].itype as Useable;
-				if (item.canUse()) {
-					outputText("You grab " + player.itemSlots[slotNum].itype.longName + " and consider what you will do with it.\n\n"
-							+"Do you use it, or destroy it?\n\n");
-					menu();	//Can't get the menu to pop up...
-					addButton(0, "Use it", handleItemInInventory, 0, item, slotNum);
-					addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
-				} else {
-					menu();
-					addButton(0, "Next", itemGoNext);
-					addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
-					//itemGoNext();
-				}
-			}
-			else {
-				outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
-				itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
-			}
+
 		}
 		*/
 		private function doWhatWithItem(slotNum:int):void {
 			clearOutput();
-			if (player.itemSlots[slotNum].itype is Useable) {
-				var item:Useable = player.itemSlots[slotNum].itype as Useable;
-				if (flags[kFLAGS.SHIFT_KEY_DOWN] == 1) {
-					deleteItemPrompt(item, slotNum);
-					return;
+			if (flags[kFLAGS.INVT_MGMT_TYPE] == 0){
+				if (player.itemSlots[slotNum].itype is Useable) {
+					var item:Useable = player.itemSlots[slotNum].itype as Useable;
+					if (flags[kFLAGS.SHIFT_KEY_DOWN] == 1) {
+						deleteItemPrompt(item, slotNum);
+						return;
+					}
+					if (item.canUse()) { //If an item cannot be used then canUse should provide a description of why the item cannot be used
+						if (!debug) player.itemSlots[slotNum].removeOneItem();
+						useItem(item, player.itemSlots[slotNum]);
+						return;
+					}
 				}
-				if (item.canUse()) { //If an item cannot be used then canUse should provide a description of why the item cannot be used
-					if (!debug) player.itemSlots[slotNum].removeOneItem();
-					useItem(item, player.itemSlots[slotNum]);
-					return;
+				else {
+					outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
+				}
+				itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
+			}	else{
+				if (player.itemSlots[slotNum].itype is Useable) {
+					var item:Useable = player.itemSlots[slotNum].itype as Useable;
+					if (item.canUse()) {
+						outputText("You grab " + player.itemSlots[slotNum].itype.longName + " and consider what you will do with it.\n\n"
+								+"Do you use it, or destroy it?\n\n");
+						menu();	//Can't get the menu to pop up...
+						addButton(0, "Use it", handleItemInInventory, 0, item, slotNum);
+						addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
+					} else {
+						menu();
+						addButton(0, "Next", itemGoNext);
+						addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
+						//itemGoNext();
+					}
+				}
+				else {
+					outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
+					itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
 				}
 			}
-			else {
-				outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
 			}
-			itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
-		}
+
 
 		private function handleItemInInventory(x:int, item:Useable, slotNum:int):void{
 			switch(x){

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -800,43 +800,36 @@ use namespace CoC;
 		*/
 		private function doWhatWithItem(slotNum:int):void {
 			clearOutput();
+			if (player.itemSlots[slotNum].itype is Useable) {
+				var item:Useable = player.itemSlots[slotNum].itype as Useable;
 			if (flags[kFLAGS.INVT_MGMT_TYPE] == 0){
-				if (player.itemSlots[slotNum].itype is Useable) {
-					var item:Useable = player.itemSlots[slotNum].itype as Useable;
-					if (flags[kFLAGS.SHIFT_KEY_DOWN] == 1) {
-						deleteItemPrompt(item, slotNum);
-						return;
-					}
-					if (item.canUse()) { //If an item cannot be used then canUse should provide a description of why the item cannot be used
-						if (!debug) player.itemSlots[slotNum].removeOneItem();
-						useItem(item, player.itemSlots[slotNum]);
-						return;
-					}
+				if (flags[kFLAGS.SHIFT_KEY_DOWN] == 1) {
+					deleteItemPrompt(item, slotNum);
+				return;
 				}
-				else {
-					outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
+				if (item.canUse()) { //If an item cannot be used then canUse should provide a description of why the item cannot be used
+					if (!debug) player.itemSlots[slotNum].removeOneItem();
+					useItem(item, player.itemSlots[slotNum]);
+					return;
 				}
 				itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
-			}	else{
-				if (player.itemSlots[slotNum].itype is Useable) {
-					var item:Useable = player.itemSlots[slotNum].itype as Useable;
-					if (item.canUse()) {
-						outputText("You grab " + player.itemSlots[slotNum].itype.longName + " and consider what you will do with it.\n\n"
-								+"Do you use it, or destroy it?\n\n");
-						menu();	//Can't get the menu to pop up...
-						addButton(0, "Use it", handleItemInInventory, 0, item, slotNum);
-						addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
-					} else {
-						menu();
-						addButton(0, "Next", itemGoNext);
-						addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
-						//itemGoNext();
-					}
+			}	else {
+				if (item.canUse()) {
+					outputText("You grab " + player.itemSlots[slotNum].itype.longName + " and consider what you will do with it.\n\n"
+							+ "Do you use it, or destroy it?\n\n");
+					menu();	//Can't get the menu to pop up...
+					addButton(0, "Use it", handleItemInInventory, 0, item, slotNum);
+					addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
+				} else {
+					menu();
+					addButton(0, "Next", itemGoNext);
+					addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
+					//itemGoNext();
 				}
-				else {
-					outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
-					itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
 				}
+			}else {
+				outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
+				itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
 			}
 			}
 

--- a/classes/classes/Scenes/Inventory.as
+++ b/classes/classes/Scenes/Inventory.as
@@ -792,8 +792,8 @@ use namespace CoC;
 				pearlStorage.push(newSlot);
 			}
 		}
-
-		private function doWhatWithItem(slotNum:int):void {
+		/*
+		private function doWhatWithItem(slotNum:int):void { //Commented out due to players probably being used to spamming tfs. Alternative idea required. But the idea for this was an extra menu between use.
 			clearOutput();
 			//menu();
 			if (player.itemSlots[slotNum].itype is Useable) {
@@ -810,8 +810,17 @@ use namespace CoC;
 					addButton(1, "Discard it", handleItemInInventory, 1, item, slotNum);
 					//itemGoNext();
 				}
-				//addButton(4,"Return to menu",itemGoNext)
-				/*
+			}
+			else {
+				outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
+				itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
+			}
+		}
+		*/
+		private function doWhatWithItem(slotNum:int):void {
+			clearOutput();
+			if (player.itemSlots[slotNum].itype is Useable) {
+				var item:Useable = player.itemSlots[slotNum].itype as Useable;
 				if (flags[kFLAGS.SHIFT_KEY_DOWN] == 1) {
 					deleteItemPrompt(item, slotNum);
 					return;
@@ -821,12 +830,11 @@ use namespace CoC;
 					useItem(item, player.itemSlots[slotNum]);
 					return;
 				}
-				*/
 			}
 			else {
 				outputText("You cannot use " + player.itemSlots[slotNum].itype.longName + "!\n\n");
-				itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
 			}
+			itemGoNext(); //Normally returns to the inventory menu. In combat it goes to the inventoryCombatHandler function
 		}
 
 		private function handleItemInInventory(x:int, item:Useable, slotNum:int):void{


### PR DESCRIPTION
Inventory revert included, because players may spam tfs and not like the extra menu. Point made rightfully by Lia.

Or we can discuss this, cause I just realized, regardless if they spam or not, if they use a tf, they still need to press next, which is only ever in the right spot 10% of the time in the menu. I.E., it really only makes them have to double tap the same spot. Perhaps on Discord.