### PR TITLE
Performance improvement for perks and status effects

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1124,7 +1124,7 @@ public class Creature extends Utils
 			ass           = new AssClass();
 			ass.host      = this;
 			breastRows    = [];
-			_perks        = [];
+			_perks        = new PerkManager(this);
 			statusEffects = [];
 			this.strStat.core.value = 15;
 			this.touStat.core.value = 15;
@@ -1248,15 +1248,37 @@ public class Creature extends Utils
 		*/
 		//Monsters have few perks, which I think should be a status effect for clarity's sake.
 		//TODO: Move perks into monster status effects.
-		private var _perks:Array;
-		public function perk(i:int):PerkClass{
-			return _perks[i];
+		private var _perks:PerkManager;
+
+		public function get perkManager():PerkManager
+		{
+			return this._perks;
 		}
+
+		/**
+		 * STOP USING THIS! Use getPerk instead!
+		 * @deprecated
+		 * @param i
+		 * @return
+		 */
+		public function perk(i:int):PerkClass {
+			return _perks.asArray()[i];
+		}
+
+		/**
+		 * Perks as an array. Only use this when needing a full list of active perks.
+		 * If searching for a perk, use hasPerk or getPerk instead.
+		 */
 		public function get perks():Array {
-			return _perks;
+			return _perks.asArray();
 		}
+
+		/**
+		 * Get count of active perks
+		 * @return {Number} Number of active perks.
+		 */
 		public function get numPerks():int {
-			return _perks.length;
+			return _perks.count();
 		}
 		//Current status effects. This has got very muddy between perks and status effects. Will have to look into it.
 		//Someone call the grammar police!
@@ -1269,87 +1291,11 @@ public class Creature extends Utils
 		//Create a perk
 		public function createPerk(ptype:PerkType, value1:Number, value2:Number, value3:Number, value4:Number):void
 		{
-			var newKeyItem:PerkClass = new PerkClass(ptype);
-			//used to denote that the array has already had its new spot pushed on.
-			var arrayed:Boolean = false;
-			//used to store where the array goes
-			var keySlot:Number = 0;
-			var counter:Number = 0;
-			//Start the array if its the first bit
-			if (perks.length == 0)
-			{
-				//trace("New Perk Started Array! " + keyName);
-				perks.push(newKeyItem);
-				arrayed = true;
-				keySlot = 0;
-			}
-			//If it belongs at the end, push it on
-			if (perk(perks.length - 1).perkName < ptype.name && !arrayed)
-			{
-				//trace("New Perk Belongs at the end!! " + keyName);
-				perks.push(newKeyItem);
-				arrayed = true;
-				keySlot = perks.length - 1;
-			}
-			//If it belongs in the beginning, splice it in
-			if (perk(0).perkName > ptype.name && !arrayed)
-			{
-				//trace("New Perk Belongs at the beginning! " + keyName);
-				perks.splice(0, 0, newKeyItem);
-				arrayed = true;
-				keySlot = 0;
-			}
-			//Find the spot it needs to go in and splice it in.
-			if (!arrayed)
-			{
-				//trace("New Perk using alphabetizer! " + keyName);
-				counter = perks.length;
-				while (counter > 0 && !arrayed)
-				{
-					counter--;
-					//If the current slot is later than new key
-					if (perk(counter).perkName > ptype.name)
-					{
-						//If the earlier slot is earlier than new key && a real spot
-						if (counter - 1 >= 0)
-						{
-							//If the earlier slot is earlier slot in!
-							if (perk(counter - 1).perkName <= ptype.name)
-							{
-								arrayed = true;
-								perks.splice(counter, 0, newKeyItem);
-								keySlot = counter;
-							}
-						}
-						//If the item after 0 slot is later put here!
-						else
-						{
-							//If the next slot is later we are go
-							if (perk(counter).perkName <= ptype.name) {
-								arrayed = true;
-								perks.splice(counter, 0, newKeyItem);
-								keySlot = counter;
-							}
-						}
-					}
-				}
-			}
-			//Fallback
-			if (!arrayed)
-			{
-				//trace("New Perk Belongs at the end!! " + keyName);
-				perks.push(newKeyItem);
-				keySlot = perks.length - 1;
-			}
-			if (ptype.buffs != null)
-			{
-				statStore.addBuffObject(ptype.buffs, "perk_"+ptype.id, {text:ptype.name, save:false});
-			}
-			perk(keySlot).value1 = value1;
-			perk(keySlot).value2 = value2;
-			perk(keySlot).value3 = value3;
-			perk(keySlot).value4 = value4;
-			//trace("NEW PERK FOR PLAYER in slot " + keySlot + ": " + perk(keySlot).perkName);
+			this._perks.createPerk(ptype, value1, value2, value3, value4);
+		}
+
+		public function addPerkInstance(pclass:PerkClass):void {
+			this._perks.add(pclass);
 		}
 
 		/**
@@ -1357,161 +1303,95 @@ public class Creature extends Utils
 		 */
 		public function removePerk(ptype:PerkType):Boolean
 		{
-			var counter:Number = perks.length;
-			//Various Errors preventing action
-			if (perks.length <= 0)
-			{
-				return false;
-			}
-			if (perkv4(ptype) > 0)
-			{
-				// trace('ERROR! Attempted to remove permanent "' + ptype.name + '" perk.');
-				return false;
-			}
-			while (counter > 0)
-			{
-				counter--;
-				if (perk(counter).ptype == ptype)
-				{
-					perks.splice(counter, 1);
-					//trace("Attempted to remove \"" + perkName + "\" perk.");
-					if (ptype.buffs != null)
-					{
-						statStore.removeBuffs("perk_"+ptype.id);
-					}
-					return true;
-				}
-			}
-			return false;
+			return this._perks.remove(ptype);
 		}
 
-		//has perk?
+		/**
+		 * STOP USING THIS! Use Creature.hasPerk or Creature.getPerk instead!
+		 * Perks are no longer stored as an array this is an extremely slow compatibility measure.
+		 * @deprecated
+		 * @see Creature.hasPerk
+		 * @see Creature.getPerk
+		 * @param ptype
+		 * @return {Number} Index of perk in array if it exists. -1 if perk does not exist.
+		 */
 		public function findPerk(ptype:PerkType):Number
 		{
-			if (perks.length <= 0)
-				return -2;
-			for (var counter:int = 0; counter<perks.length; counter++)
-			{
-				if (perk(counter).ptype.id == ptype.id)
-					return counter;
+			trace("Find perk :( - " + ptype.id);
+			var perk:PerkClass = this._perks.get(ptype);
+			if (perk) {
+				return this._perks.asArray().indexOf(perk);
 			}
 			return -1;
 		}
+
+		/**
+		 * Check if this creature has a perk.
+		 * @param ptype {PerkType}
+		 * @return {Boolean} True if creature has the perk, otherwise false.
+		 */
 		public function hasPerk(ptype:PerkType):Boolean {
-			return findPerk(ptype) >= 0;
+			return this._perks.has(ptype);
 		}
 
-		//Duplicate perk
-		//Deprecated?
+		/**
+		 * Get the instance of a perk.
+		 * @param {PerkType} ptype
+		 */
+		public function getPerk(ptype:PerkType):PerkClass {
+			return this._perks.get(ptype);
+		}
+
+		/**
+		 * Check if a perk is duplicated.
+		 * Always returns false as PerkManager forbids duplicates. Attempting to add an existing perk keeps the original
+		 * perk and aborts adding the new one.
+		 * @deprecated
+		 * @return {Boolean} False.
+		 */
 		public function perkDuplicated(ptype:PerkType):Boolean
 		{
-			var timesFound:int = 0;
-			if (perks.length <= 0)
-				return false;
-			for (var counter:int = 0; counter<perks.length; counter++)
-			{
-				if (perk(counter).ptype == ptype)
-					timesFound++;
-			}
-			return (timesFound > 1);
+			return false;
 		}
 
 		//remove all perks
 		public function removePerks():void
 		{
-			for each(var pc:PerkClass in _perks){
-				this.statStore.removeBuffs("perk_"+pc.ptype.id);
+			for each(var pc:PerkClass in _perks.asArray()){
+				this._perks.remove(pc.ptype);
 			}
-			_perks = [];
+			_perks.clear(); // Clean up anything else, just in case.
 		}
 
 		public function addPerkValue(ptype:PerkType, valueIdx:Number = 1, bonus:Number = 0): void
 		{
-			var counter:int = findPerk(ptype);
-			if (counter < 0) {
-				trace("ERROR? Looking for perk '" + ptype + "' to change value " + valueIdx + ", and player does not have the perk.");
-				return;
-			}
-			if (valueIdx < 1 || valueIdx > 4) {
-				CoC_Settings.error("addPerkValue(" + ptype.id + ", " + valueIdx + ", " + bonus + ").");
-				return;
-			}
-			if (valueIdx == 1)
-				perk(counter).value1 += bonus;
-			if (valueIdx == 2)
-				perk(counter).value2 += bonus;
-			if (valueIdx == 3)
-				perk(counter).value3 += bonus;
-			if (valueIdx == 4)
-				perk(counter).value4 += bonus;
+			this._perks.addPerkValue(ptype, valueIdx, bonus);
 		}
 
 		public function setPerkValue(ptype:PerkType, valueIdx:Number = 1, newNum:Number = 0): void
 		{
-			var counter:Number = findPerk(ptype);
-			//Various Errors preventing action
-			if (counter < 0) {
-				trace("ERROR? Looking for perk '" + ptype + "' to change value " + valueIdx + ", and player does not have the perk.");
-				return;
-			}
-			if (valueIdx < 1 || valueIdx > 4)
-			{
-				CoC_Settings.error("setPerkValue(" + ptype.id + ", " + valueIdx + ", " + newNum + ").");
-				return;
-			}
-			if (valueIdx == 1)
-				perk(counter).value1 = newNum;
-			if (valueIdx == 2)
-				perk(counter).value2 = newNum;
-			if (valueIdx == 3)
-				perk(counter).value3 = newNum;
-			if (valueIdx == 4)
-				perk(counter).value4 = newNum;
+			this._perks.setPerkValue(ptype, valueIdx, newNum);
 		}
 
 		public function perkv1(ptype:PerkType):Number
 		{
-			var counter:Number = findPerk(ptype);
-			if (counter < 0)
-			{
-				// trace("ERROR? Looking for perk '" + ptype + "', but player does not have it.");
-				return 0;
-			}
-			return perk(counter).value1;
+			return this._perks.getPerkValue(ptype, 1);
 		}
 
-	public function perkv2(ptype:PerkType):Number
-	{
-		var counter:Number = findPerk(ptype);
-		if (counter < 0)
+		public function perkv2(ptype:PerkType):Number
 		{
-			// trace("ERROR? Looking for perk '" + ptype + "', but player does not have it.");
-			return 0;
+			return this._perks.getPerkValue(ptype, 2);
 		}
-		return perk(counter).value2;
-	}
 
-	public function perkv3(ptype:PerkType):Number
-	{
-		var counter:Number = findPerk(ptype);
-		if (counter < 0)
+		public function perkv3(ptype:PerkType):Number
 		{
-			trace("ERROR? Looking for perk '" + ptype + "', but player does not have it.");
-			return 0;
+			return this._perks.getPerkValue(ptype, 3);
 		}
-		return perk(counter).value3;
-	}
 
-	public function perkv4(ptype:PerkType):Number
-	{
-		var counter:Number = findPerk(ptype);
-		if (counter < 0)
+		public function perkv4(ptype:PerkType):Number
 		{
-			// trace("ERROR? Looking for perk '" + ptype + "', but player does not have it.");
-			return 0;
+			return this._perks.getPerkValue(ptype, 4);
 		}
-		return perk(counter).value4;
-	}
 
 		/*
 

--- a/classes/classes/PerkManager.as
+++ b/classes/classes/PerkManager.as
@@ -1,0 +1,208 @@
+package classes {
+import flash.utils.Dictionary;
+
+public class PerkManager {
+    private var perks:Dictionary;
+    private var actor:Creature;
+    private var arrayCache:Array;
+
+    /**
+     *
+     * @param owner {Creature} Optional. Creature to associate with this perk manager for buff add/remove.
+     */
+    public function PerkManager(owner:Creature = undefined) {
+        if (owner) {
+            this.attach(owner);
+        }
+        this.clear();
+    }
+
+    /**
+     * Associate an actor (Creature) to this perk manager. Overwrites any existing association.
+     * @param actor {Creature}
+     */
+    public function attach(actor:Creature):void
+    {
+        this.actor = actor;
+    }
+
+    /**
+     * Create a perk instance and add it.
+     * @param ptype {PerkType} Perk type descriptor to create an instance of.
+     * @param value1 {Number} Optional. Defaults to 0
+     * @param value2 {Number} Optional. Defaults to 0
+     * @param value3 {Number} Optional. Defaults to 0
+     * @param value4 {Number} Optional. Defaults to 0
+     * @return {Boolean} True if perk is added. False if perk already exists or fails to add.
+     */
+    public function createPerk(ptype:PerkType, value1:Number = 0, value2:Number = 0, value3:Number = 0, value4:Number = 0):Boolean
+    {
+        // Checking if the perk exists first just in case a perk does something silly on creation.
+        if (this.has(ptype)) {
+            return false;
+        }
+        var newPerk:PerkClass = new PerkClass(ptype, value1, value2, value3, value4);
+        return this.add(newPerk);
+    }
+
+    /**
+     * Add a perk instance.
+     * @param perk {PerkClass} Perk instance to add
+     * @return {Boolean} True if perk is added. False if perk already exists or fails to add.
+     */
+    public function add(perk:PerkClass):Boolean {
+        trace("Attempting to add perk " + perk.ptype.id + " to " + this.actor.short);
+        if (this.has(perk.ptype)) {
+            trace("Perk " + perk.ptype.id + " already exists. Aborted.");
+            return false;
+        }
+        this.perks[perk.ptype.id] = perk;
+        if (perk.ptype.buffs != null) {
+            trace("Perk " + perk.ptype.id + " has buffs.");
+            this.actor.statStore.addBuffObject(
+                    perk.ptype.buffs,
+                    "perk_"+perk.ptype.id,
+                    {text:perk.perkName, save:false}
+            );
+        }
+        this.arrayCache = null; // Invalidate array cache.
+        trace("Perk " + perk.ptype.id + " added.");
+        return true;
+    }
+
+    /**
+     * Remove a perk.
+     * @param ptype {PerkType} Perk type descriptor to remove
+     * @return {Boolean} True if perk removed, false if perk did not exist.
+     */
+    public function remove(ptype:PerkType): Boolean {
+        if (this.has(ptype)) {
+            delete this.perks[ptype.id];
+            if (ptype.buffs) {
+                this.actor.statStore.removeBuffs("perk_"+ptype.id);
+            }
+            this.arrayCache = null;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if this perk manager has a perk.
+     * @param ptype
+     * @return
+     */
+    public function has(ptype:PerkType): Boolean {
+        return this.perks[ptype.id] !== undefined;
+    }
+
+    /**
+     * Clear all perks without individually removing them.
+     * Use with caution as buffs are not cleaned up.
+     */
+    public function clear(): void {
+        this.perks = new Dictionary();
+        this.arrayCache = null;
+    }
+
+    /**
+     * Number of active perks
+     * @return {Number}
+     */
+    public function count(): Number {
+        return this.perks.length;
+    }
+
+    /**
+     * Get a perk instance.
+     * @param ptype {PerkType}
+     * @return {PerkClass} PerkClass if PerkType exists in this manager. Otherwise undefined.
+     */
+    public function get(ptype:PerkType): PerkClass {
+        return this.perks[ptype.id];
+    }
+
+    /**
+     * Returns a shallow-copied array of all perks on this PerkManager.
+     * @return {Array<PerkClass>}
+     */
+    public function asArray(): Array
+    {
+        if (this.arrayCache == null) {
+            this.arrayCache = [];
+            for each(var perk:PerkClass in this.perks) {
+                this.arrayCache.push(perk);
+            }
+            this.arrayCache.sortOn("perkName"); // Pre-sort for compatibility.
+        }
+        return this.arrayCache;
+    }
+
+    /**
+     * Get a value for a perk.
+     * @param ptype {PerkType} Target perk.
+     * @param valueIdx {Number} Index of value to get, 1 through 4.
+     * @return {Number} 0 if perk does not exist.
+     */
+    public function getPerkValue(ptype:PerkType, valueIdx:Number = 1): Number
+    {
+        var perk:PerkClass = this.get(ptype);
+        if (perk) {
+            switch (valueIdx) {
+                case 1:
+                    return perk.value1;
+                case 2:
+                    return perk.value2
+                case 3:
+                    return perk.value3;
+                case 4:
+                    return perk.value4;
+                default:
+                    CoC_Settings.error("Invalid perk value index. Attempted to get perk " + ptype.id + " value " + valueIdx +" ).");
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Modify a value for a perk.
+     * @param ptype {PerkType} Target perk.
+     * @param valueIdx {Number} Index of value to modify, 1 through 4.
+     * @param bonus {Number} Amount to add to perk value.
+     */
+    public function addPerkValue(ptype:PerkType, valueIdx:Number = 1, bonus:Number = 0): void
+    {
+        this.setPerkValue(ptype, valueIdx, this.getPerkValue(ptype, valueIdx) + bonus);
+    }
+
+    /**
+     * Set a value for a perk.
+     * @param ptype {PerkType} Target perk.
+     * @param valueIdx {Number} Index of value to set, 1 through 4.
+     * @param newNum {Number} Value to set.
+     */
+    public function setPerkValue(ptype:PerkType, valueIdx:Number = 1, newNum:Number = 0): void
+    {
+        // Do not invalidate the array cache for value modifications. Array cache is a shallow copy.
+        var perk:PerkClass = this.get(ptype);
+        if (perk) {
+            switch (valueIdx) {
+                case 1:
+                    perk.value1 = newNum;
+                    return;
+                case 2:
+                    perk.value2 = newNum;
+                    return;
+                case 3:
+                    perk.value3 = newNum;
+                    return;
+                case 4:
+                    perk.value4 = newNum;
+                    return;
+                default:
+                    CoC_Settings.error("Invalid perk value index. Attempted to set perk " + ptype.id + " value " + valueIdx + " to " + newNum+ ").");
+            }
+        }
+    }
+}
+}

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1076,21 +1076,16 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 			saveFile.data.perks.push(savePerk);
 		});
 
-		//Set Status Array
-		for (i = 0; i < player.statusEffects.length; i++)
-		{
-			saveFile.data.statusAffects.push([]);
-				//trace("Saveone statusEffects");
-		}
 		//Populate Status Array
-		for (i = 0; i < player.statusEffects.length; i++)
-		{
-			//trace("Populate One statusEffects");
-			saveFile.data.statusAffects[i].statusAffectName = player.statusEffectByIndex(i).stype.id;
-			saveFile.data.statusAffects[i].value1 = player.statusEffectByIndex(i).value1;
-			saveFile.data.statusAffects[i].value2 = player.statusEffectByIndex(i).value2;
-			saveFile.data.statusAffects[i].value3 = player.statusEffectByIndex(i).value3;
-			saveFile.data.statusAffects[i].value4 = player.statusEffectByIndex(i).value4;
+		for each(var statusEffect:StatusEffectClass in player.statusEffects) {
+			var saveStatusEffect: Object = {
+				statusAffectName: statusEffect.stype.id,
+				value1: statusEffect.value1,
+				value2: statusEffect.value2,
+				value3: statusEffect.value3,
+				value4: statusEffect.value4
+			};
+			saveFile.data.statusAffects.push(saveStatusEffect);
 		}
 		//Set keyItem Array
 		for (i = 0; i < player.keyItems.length; i++)

--- a/classes/classes/Saves.as
+++ b/classes/classes/Saves.as
@@ -1065,19 +1065,16 @@ public function saveGameObject(slot:String, isFile:Boolean):void
 		}
 		//Set Perk Array
 		//Populate Perk Array
-		for (i = 0; i < player.perks.length; i++)
-		{
-			saveFile.data.perks.push([]);
-			//trace("Saveone Perk");
-			//trace("Populate One Perk");
-			saveFile.data.perks[i].id = player.perk(i).ptype.id;
-			//saveFile.data.perks[i].perkName = player.perk(i).ptype.id; //uncomment for backward compatibility
-			saveFile.data.perks[i].value1 = player.perk(i).value1;
-			saveFile.data.perks[i].value2 = player.perk(i).value2;
-			saveFile.data.perks[i].value3 = player.perk(i).value3;
-			saveFile.data.perks[i].value4 = player.perk(i).value4;
-			//saveFile.data.perks[i].perkDesc = player.perk(i).perkDesc; // uncomment for backward compatibility
-		}
+		player.perks.forEach(function (perk:PerkClass, ...args):void {
+			var savePerk: Object = {
+				id: perk.ptype.id,
+				value1: perk.value1,
+				value2: perk.value2,
+				value3: perk.value3,
+				value4: perk.value4
+			};
+			saveFile.data.perks.push(savePerk);
+		});
 
 		//Set Status Array
 		for (i = 0; i < player.statusEffects.length; i++)
@@ -2326,24 +2323,25 @@ public function loadGameObject(saveData:Object, slot:String = "VOID"):void
 				// NEVER EVER EVER MODIFY DATA IN THE SAVE FILE LIKE THIS. EVER. FOR ANY REASON.
 			} else {
 				trace("Creating perk : " + ptype);
-				player.createPerk(ptype, value1, value2, value3, value4);
+				var cperk:PerkClass = new PerkClass(ptype, value1, value2, value3, value4);
 
-				if (isNaN(player.perk(player.numPerks - 1).value1)) {
-					if (player.perk(player.numPerks - 1).perkName == "Wizard's Focus") {
-						player.perk(player.numPerks - 1).value1 = .3;
+				if (isNaN(cperk.value1)) {
+					if (cperk.perkName == "Wizard's Focus") {
+						cperk.value1 = .3;
 					} else {
-						player.perk(player.numPerks).value1 = 0;
+						cperk.value1 = 0;
 					}
 
-					trace("NaN byaaaatch: " + player.perk(player.numPerks - 1).value1);
+					trace("NaN byaaaatch: " + cperk.value1);
 				}
 
-				if (player.perk(player.numPerks - 1).perkName == "Wizard's Focus") {
-					if (player.perk(player.numPerks - 1).value1 == 0 || player.perk(player.numPerks - 1).value1 < 0.1) {
+				if (cperk.perkName == "Wizard's Focus") {
+					if (cperk.value1 == 0 || cperk.value1 < 0.1) {
 						trace("Wizard's Focus boosted up to par (.5)");
-						player.perk(player.numPerks - 1).value1 = .5;
+						cperk.value1 = .5;
 					}
 				}
+				player.addPerkInstance(cperk);
 			}
 		}
 

--- a/classes/classes/StatusEffectManager.as
+++ b/classes/classes/StatusEffectManager.as
@@ -1,0 +1,153 @@
+package classes {
+
+import flash.utils.Dictionary;
+
+public class StatusEffectManager {
+    private var statusEffects:Dictionary;
+    private var actor:Creature;
+
+    /**
+     *
+     * @param owner {Creature} Optional. Creature to associate with this manager for buff add/remove.
+     */
+    public function StatusEffectManager(owner:Creature = undefined)
+    {
+        if (owner) {
+            this.attach(owner);
+        }
+        this.removeStatuses();
+    }
+
+    /**
+     * Associate an actor (Creature) to this status manager. Overwrites any existing association.
+     * @param actor {Creature}
+     */
+    public function attach(actor:Creature):void
+    {
+        this.actor = actor;
+    }
+
+    public function hasStatusEffect(stype:StatusEffectType):Boolean
+    {
+        return this.statusEffects[stype.id] != undefined;
+    }
+
+    public function statusEffectByType(stype:StatusEffectType): StatusEffectClass
+    {
+        return this.statusEffects[stype.id] || null;
+    }
+
+    public function createStatusEffect(stype:StatusEffectType, v1:Number, v2:Number, v3:Number, v4:Number, fireEvent:Boolean = true): StatusEffectClass
+    {
+        if (this.hasStatusEffect(stype)) {
+            return undefined;
+        }
+        var sec:StatusEffectClass = stype.create(v1, v2, v3, v4);
+        this.addStatusEffect(sec);
+        return sec;
+    }
+
+    public function createOrFindStatusEffect(stype:StatusEffectType, v1:Number = 0, v2:Number = 0, v3:Number = 0, v4:Number = 0, fireEvent:Boolean = true):StatusEffectClass
+    {
+        if (this.hasStatusEffect(stype)) {
+            return this.statusEffectByType(stype);
+        }
+        return this.createStatusEffect(stype, v1, v2, v3, v4, fireEvent);
+    }
+
+    public function addStatusEffect(sec:StatusEffectClass):void
+    {
+        if (this.hasStatusEffect(sec.stype)) {
+            trace("addStatusEffect: stype "+ sec.stype.id + " already exists");
+            return;
+        }
+
+        if (sec.host != this.actor) {
+            // Automatically transfer status effects?
+            sec.remove();
+            sec.attach(this.actor /*,fireEvent*/);
+        } else {
+            this.statusEffects[sec.stype.id] = sec;
+            sec.addedToHostList(this.actor,true);
+        }
+    }
+
+    public function removeStatusEffect(stype:StatusEffectType):StatusEffectClass
+    {
+        var sec:StatusEffectClass = this.statusEffectByType(stype);
+        if (sec) {
+            sec.removedFromHostList(true);
+            delete this.statusEffects[sec.stype.id];
+            return sec;
+        }
+        return null;
+    }
+
+    public function removeStatusEffectInstance(sec:StatusEffectClass):void
+    {
+        /* Not trusting that the supplied StatusEffectClass instance exists on this
+           StatusEffectManager.
+         */
+        this.removeStatusEffect(sec.stype);
+    }
+
+    public function changeStatusValue(stype:StatusEffectType, statusValueNum:Number = 1, newNum:Number = 0):void
+    {
+        if (statusValueNum < 1 || statusValueNum > 4) {
+            CoC_Settings.error("ChangeStatusValue called with invalid status value number.");
+            return;
+        }
+        var sac:StatusEffectClass = this.statusEffectByType(stype);
+        //Various Errors preventing action
+        if (!sac)return;
+        if (statusValueNum == 1) sac.value1 = newNum;
+        if (statusValueNum == 2) sac.value2 = newNum;
+        if (statusValueNum == 3) sac.value3 = newNum;
+        if (statusValueNum == 4) sac.value4 = newNum;
+    }
+
+    public function addStatusValue(stype:StatusEffectType, statusValueNum:Number = 1, bonus:Number = 0):void
+    {
+        if (statusValueNum < 1 || statusValueNum > 4) {
+            CoC_Settings.error("ChangeStatusValue called with invalid status value number.");
+            return;
+        }
+        var sac:StatusEffectClass = this.statusEffectByType(stype);
+        //Various Errors preventing action
+        if (!sac)return;
+        if (statusValueNum == 1) sac.value1 += bonus;
+        if (statusValueNum == 2) sac.value2 += bonus;
+        if (statusValueNum == 3) sac.value3 += bonus;
+        if (statusValueNum == 4) sac.value4 += bonus;
+    }
+
+    public function getStatusValue(stype:StatusEffectType, statusValueNum:Number): Number
+    {
+        if (statusValueNum < 1 || statusValueNum > 4) {
+            CoC_Settings.error("getStatusValue called with invalid status value number.");
+            return 0;
+        }
+        var sac:StatusEffectClass = this.statusEffectByType(stype);
+        if (!sac) return 0;
+        if (statusValueNum == 1) return sac.value1;
+        if (statusValueNum == 2) return sac.value2;
+        if (statusValueNum == 3) return sac.value3;
+        if (statusValueNum == 4) return sac.value4;
+        return 0;
+    }
+
+    public function removeStatuses():void
+    {
+        this.statusEffects = new Dictionary();
+    }
+
+    public function asArray():Array
+    {
+        var array:Array = [];
+        for each(var sec:StatusEffectClass in this.statusEffects) {
+            array.push(sec);
+        }
+        return array;
+    }
+}
+}

--- a/classes/classes/StatusEffects.as
+++ b/classes/classes/StatusEffects.as
@@ -1139,4 +1139,4 @@ import classes.StatusEffects.VampireThirstEffect;
 			return new StatusEffectType(id,CombatStatusEffect,1);
 		}
 	}
-}
+}


### PR DESCRIPTION
These changes implement perks and status effects as dictionaries instead of arrays for significantly faster look-ups. Solves some of the performance issues in https://github.com/Ormael7/Corruption-of-Champions/issues/121

### PerkManager
- Added a new class classes.PerkManager to hold the add/remove/etc logic for perks.
- The perk functions within classes.Creature are changed to small shim functions for compatibility.
- Creature.findPerk() Creature.perk() are emulated by creating a sorted array of perks. This should be the same stablity as before, any stored index for a perk would be invalid if the perk list changes.

### StatusEffectManager
- Mostly small adjustments to reference status effects within a dictionary instead of array scanning. 
- Moved status effect add/remove/etc logic into StatusEffectManager mainly to separate the code. Most of the status effect functions in Creature just point at StatusEffectManager classes.
- Removed the status effect by index functions as they were no longer used with the updated save code.

I do have a refactor of all findPerk calls to equivalent hasPerk and getPerk calls. It is massive and I don't think should be in this PR. I included some testing results from that branch below though.

### Results
On a lvl 105 save with the 10 attack melee perks, I was getting 10-20 second long pauses when doing the basic attack action. Sleep and long waits were even longer. After looking into some performance profiling, perk lookups seemed to be the main culprit.

Testing wait until dusk from 10:00am, both from a fresh load of the same save.

Original (https://github.com/Ormael7/Corruption-of-Champions/commit/53fa92ba87ffe0c42f82e4f5d350932bed45eb63):
```
[trace] [PROFILE] eventParser.goNext(11) 38908ms, 2718 internal calls
```

With findPerk calls as-is
```
[trace] [PROFILE] eventParser.goNext(11) 3589ms, 2718 internal calls
```

With findPerk calls refactored to hasPerk and getPerk:
```
[trace] [PROFILE] eventParser.goNext(11) 871ms, 2718 internal calls
```
