### PR TITLE
un-buffs beginner enemies on low difficulties

### DIFF
--- a/classes/classes/Monster.as
+++ b/classes/classes/Monster.as
@@ -304,7 +304,7 @@ import flash.utils.getQualifiedClassName;
 				else temp *= 0.6;
 			}
 			temp = Math.round(temp);
-			if (temp < (300 + (100 * newGamePlusMod()))) temp = (300 + (100 * newGamePlusMod()));
+			if (temp < (130 + 20 * this.level + (100 * newGamePlusMod()))) temp = (130 + 20 * this.level + (100 * newGamePlusMod()));
 			return temp;
 		}
 		public override function maxHP():Number {


### PR DESCRIPTION
slightly changes maxhp_base() minimum scaling to bring low level enemies in line on sub-xianxia difficulties instead of them getting buffed

commit formula: (130 + 20 * this.level + (100 * newGamePlusMod()))
alternative formula thought: (130 + 10 * this.level * (flags[kFLAGS.GAME_DIFFICULTY]+1) + (100 * newGamePlusMod()))