### PR TITLE
Temporary fix for corrupted/enlightened kitsune-ascension bug. 

### DIFF
--- a/classes/classes/CharCreation.as
+++ b/classes/classes/CharCreation.as
@@ -2934,11 +2934,26 @@ import coc.view.MainView;
 			}
 			reincarnate();
 		}
+
+		private function removePerksThatShouldntBeFuckingPermanent():void {
+			if (player.hasPerk(PerkLib.ELFElvenSpearDancingFlurry1to4))
+				player.removePerk(PerkLib.ELFElvenSpearDancingFlurry1to4);
+			if (player.hasPerk(PerkLib.CorruptedNinetails) && player.perkv4(PerkLib.CorruptedNinetails) == 0 )
+				player.removePerk(PerkLib.CorruptedNinetails);
+			if (player.hasPerk(PerkLib.CorruptedKitsune) && player.perkv4(PerkLib.CorruptedKitsune) == 0 )
+				player.removePerk(PerkLib.CorruptedKitsune);
+			if (player.hasPerk(PerkLib.EnlightenedNinetails) && player.perkv4(PerkLib.EnlightenedNinetails) == 0 )
+				player.removePerk(PerkLib.EnlightenedNinetails);
+			if (player.hasPerk(PerkLib.EnlightenedKitsune) && player.perkv4(PerkLib.EnlightenedKitsune) == 0 )
+				player.removePerk(PerkLib.EnlightenedKitsune);
+		}
+
 		private function reincarnate():void {
 			Metamorph.resetMetamorph();
 			player.createKeyItem("Ascension", 0, 0, 0, 0);
 			customPlayerProfile = null;
 			newGameGo();
+			removePerksThatShouldntBeFuckingPermanent();
 			if (flags[kFLAGS.NEW_GAME_PLUS_LEVEL] == 0.5){
 				flags[kFLAGS.NEW_GAME_PLUS_LEVEL] = 0
 			}


### PR DESCRIPTION
Probably a more fundamental problem in perks since there are a few oddities where they are requested in bulk. Re:PerkDB missing perks when it should have all of them, no exceptions.