### PR TITLE
No more tentUnlim :(

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1174,16 +1174,16 @@ public class Creature extends Utils
 
 		public function get clitLength():Number {
 			if (vaginas.length==0) {
-				trace("[ERROR] get clitLength called with no vaginas present");
-				return VaginaClass.DEFAULT_CLIT_LENGTH;
+				throw new Error("[ERROR] get clitLength called with no vaginas present");
+				//return VaginaClass.DEFAULT_CLIT_LENGTH;
 			}
 			return vaginas[0].clitLength;
 		}
 
 		public function set clitLength(value:Number):void {
 			if (vaginas.length==0) {
-				trace("[ERROR] set clitLength called with no vaginas present");
-				return;
+				throw new Error("[ERROR] set clitLength called with no vaginas present");
+				//return;
 			}
 			vaginas[0].clitLength = value;
 		}
@@ -1879,7 +1879,7 @@ public class Creature extends Utils
                                 compareBy == "thickness" ? cocks[num].cockThickness :
                                 cockArea(num);
                 if ((nsize >= minSize || minSize < 0) && (nsize < maxSize || maxSize < 0 || tentUnlim && cockIsTentacle(num))
-                && (cocks[num].cockType == type || tent && cockIsTentacle(num) || type == CockTypesEnum.UNDEFINED)) {
+                && (type == CockTypesEnum.UNDEFINED || cocks[num].cockType == type || tent && cockIsTentacle(num))) {
                     var j:int;
                     for (j = 0; j < sorted.length; ++j) {
                         var jsize:Number = compareBy == "length" ? cocks[sorted[j]].cockLength :

--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -1835,10 +1835,9 @@ public class Creature extends Utils
         * @param    minSize     Minimum size, 0/-1 = no checking
         * @param    maxSize     Maximum size, -1 = no checking
         * @param    compareBy   The measurement to compare by, "area", "length" or "thickness"
-        * @param    tentUnlim   If true, doesn't check the maximum size for tentacle cocks (you can twist them, makes sense?)
         * @return   The count of matching dicks
         */
-        public function countCocksWithType(type:CockTypesEnum, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area", tentUnlim:Boolean = true):int {
+        public function countCocksWithType(type:CockTypesEnum, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area"):int {
             if (compareBy != "area" && compareBy != "length" && compareBy != "thickness") //sanity check
                 throw new Error("Wrong compareBy value!");
             var cnt:int = 0;
@@ -1847,15 +1846,15 @@ public class Creature extends Utils
                 var isize:Number = compareBy == "length" ? cocks[i].cockLength :
                                 compareBy == "thickness" ? cocks[i].cockThickness :
                                 cockArea(i);
-                if ((isize >= minSize || minSize < 0) && (isize < maxSize || maxSize < 0 || tentUnlim && cockIsTentacle(i))
+                if ((isize >= minSize || minSize < 0) && (isize < maxSize || maxSize < 0)
                 && (cocks[i].cockType == type || tent && cockIsTentacle(i) || type == CockTypesEnum.UNDEFINED))
                     ++cnt;
             }
             return cnt;
         }
 		
-		public function countCocks(minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area", tentUnlim:Boolean = true):int {
-			return countCocksWithType(CockTypesEnum.UNDEFINED, minSize, maxSize, compareBy, tentUnlim);
+		public function countCocks(minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area"):int {
+			return countCocksWithType(CockTypesEnum.UNDEFINED, minSize, maxSize, compareBy);
 		}
 
         /**
@@ -1868,7 +1867,7 @@ public class Creature extends Utils
         * @param    compareBy   The measurement to compare by, "area", "length" or "thickness"
         * @return   The number of the biggest (comparing by 'compareBy') matching dick, -1 if no any
         */
-        public function findCockWithType(type:CockTypesEnum, biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area", tentUnlim:Boolean = true):int {
+        public function findCockWithType(type:CockTypesEnum, biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area"):int {
             if (compareBy != "area" && compareBy != "length" && compareBy != "thickness") //sanity check
                 throw new Error("Wrong compareBy value!");
             var sorted:Array = [];
@@ -1878,7 +1877,7 @@ public class Creature extends Utils
                 var nsize:Number = compareBy == "length" ? cocks[num].cockLength :
                                 compareBy == "thickness" ? cocks[num].cockThickness :
                                 cockArea(num);
-                if ((nsize >= minSize || minSize < 0) && (nsize < maxSize || maxSize < 0 || tentUnlim && cockIsTentacle(num))
+                if ((nsize >= minSize || minSize < 0) && (nsize < maxSize || maxSize < 0)
                 && (type == CockTypesEnum.UNDEFINED || cocks[num].cockType == type || tent && cockIsTentacle(num))) {
                     var j:int;
                     for (j = 0; j < sorted.length; ++j) {
@@ -1904,11 +1903,11 @@ public class Creature extends Utils
 			return sorted[0];
         }
 		
-		public function findCock(biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area", tentUnlim:Boolean = true):int {
-			return findCockWithType(CockTypesEnum.UNDEFINED, biggest, minSize, maxSize, compareBy, tentUnlim);
+		public function findCock(biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area"):int {
+			return findCockWithType(CockTypesEnum.UNDEFINED, biggest, minSize, maxSize, compareBy);
 		}
 
-        public function findCockWithTypeNotIn(arr:Array, type:CockTypesEnum, biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area", tentUnlim:Boolean = true):int {
+        public function findCockWithTypeNotIn(arr:Array, type:CockTypesEnum, biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area"):int {
             var ret:int = -1;
             var sign:int = (biggest >= 0) ? 1 : -1;
             var cnt:int = sign;
@@ -1916,7 +1915,7 @@ public class Creature extends Utils
             //correct 'biggest' value to account for zeros
             if (biggest == 0) biggest = 1;
             do {
-                ret = findCockWithType(type, cnt, minSize, maxSize, compareBy, tentUnlim); //find n-th cock
+                ret = findCockWithType(type, cnt, minSize, maxSize, compareBy); //find n-th cock
                 if (ret >= 0 && arr.indexOf(ret) == -1) { //count those outside of the array
                     if (biggest_cnt == biggest) //if found b-th cock, return it
                         return ret;
@@ -1928,8 +1927,8 @@ public class Creature extends Utils
             return -1;
         }
 
-		public function findCockNotIn(arr:Array, biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area", tentUnlim:Boolean = true):int {
-			return findCockWithTypeNotIn(arr, CockTypesEnum.UNDEFINED, biggest, minSize, maxSize, compareBy, tentUnlim);
+		public function findCockNotIn(arr:Array, biggest:int = 1, minSize:Number = -1, maxSize:Number = -1, compareBy:String = "area"):int {
+			return findCockWithTypeNotIn(arr, CockTypesEnum.UNDEFINED, biggest, minSize, maxSize, compareBy);
 		}
 
 		public function cockDescript(cockIndex:int = 0):String

--- a/classes/classes/GlobalFlags/kFLAGS.as
+++ b/classes/classes/GlobalFlags/kFLAGS.as
@@ -20,8 +20,8 @@ public static const TIMES_FUCKED_URTA:int                                       
 public static const URTA_COMFORTABLE_WITH_OWN_BODY:int                              =   12; // URTA - horsecock comfort level (-1 = hates self, no luvs)
 public static const URTA_TIME_SINCE_LAST_CAME:int                                   =   13; // URTA - hours until can be horny again
 public static const PC_SEEN_URTA_SEX_TOYS:int                                       =   14; // URTA - seen Urta's toyz?
-public static const PLAYER_RESISTED_AKBAL:int                                       =   15; // Akbal resisted?  - 1 means the PC has resisted at least once
-public static const AKBAL_SUBMISSION_COUNTER:int                                    =   16; // Akbal submission counter
+public static const UNKNOWN_FLAG_NUMBER_0015:int                                    =   15;
+public static const AKBAL_SUBMISSION_COUNTER:int                                    =   16; // Akbal submission counter (resisting resets it
 public static const AKBAL_SUBMISSION_STATE:int                                      =   17; // Akbal submission state. -1=Lost to him, 1=Beaten him, 2=Akbal is your bitch
 public static const MINOTAUR_CUM_ADDICTION_TRACKER:int                              =   18; // Minotaur cum Addiction Tracker
 public static const TIME_SINCE_LAST_CONSUMED_MINOTAUR_CUM:int                       =   19; // Time Since Last Minocum fix

--- a/classes/classes/Items/Consumables/ElementalPearl.as
+++ b/classes/classes/Items/Consumables/ElementalPearl.as
@@ -67,7 +67,7 @@ public class ElementalPearl extends Consumable {
 
     public function eatIt():void {
         clearOutput();
-        outputText("You cram the pearl in your mouth and swallow it like a giant pill with some difficulty.  Surprisingly there is no discomfort, only a calming sensation of three steams of mystical energies spreading in your body and restoring your lost strength, speed and toughness.");
+        outputText("You cram the pearl in your mouth and swallow it like a giant pill with some difficulty.  Surprisingly there is no discomfort, only a calming sensation of three steams of mystical energies spreading in your body and restoring your lost strength, speed and toughness.\n\n");
         player.createPerk(itemPerk, 0, 0, 0, 0);
         outputText("<b>Gained perk: " + itemPerk.name() + "</b>")
         SceneLib.inventory.itemGoNext();

--- a/classes/classes/Items/Weapons/NocturnusStaff.as
+++ b/classes/classes/Items/Weapons/NocturnusStaff.as
@@ -28,7 +28,7 @@ package classes.Items.Weapons
 		public function calcWizardsMult():Number {
 			var multadd:Number = 0.6;
             if (game && game.player)
-                multadd += game.player.cor * 0.044;
+                multadd += game.player.cor * 0.05;
 			return multadd;
 		}
 

--- a/classes/classes/Items/Weapons/UnicornStaff.as
+++ b/classes/classes/Items/Weapons/UnicornStaff.as
@@ -29,7 +29,7 @@ package classes.Items.Weapons
 		public function calcWizardsMult():Number {
 			var multadd:Number = 0.6;
             if (game && game.player)
-                multadd += (100 - game.player.cor) * 0.34;
+                multadd += (100 - game.player.cor) * 0.034;
 			return multadd;
 		}
 

--- a/classes/classes/SceneHunter.as
+++ b/classes/classes/SceneHunter.as
@@ -198,7 +198,7 @@ public class SceneHunter extends BaseContent {
     public function selectFitNofit(fitF:Function, nofitF:Function, maxSize:Number, compareBy:String = "area"):void {
         //Auto-calls
         if (!dickSelect) {
-            if (player.findCock(1, -1, maxSize, compareBy, false) >= 0) {
+            if (player.findCock(1, -1, maxSize, compareBy) >= 0) {
                 print("Failed/passed size check - dick fits, but you certainly can try to use something <i>bigger</i> than " + maxSize + " " + compareBy);
                 fitF();
             }
@@ -213,12 +213,12 @@ public class SceneHunter extends BaseContent {
         outputText("\n\n<b>Will you use the dick that will certainly fit, or press your luck and try to use a bigger 'tool'?</b>");
         menu();
         //fitting cocks
-        if (player.findCock(1, -1, maxSize, compareBy, true) >= 0)
+        if (player.findCock(1, -1, maxSize, compareBy) >= 0)
             addButton(0, "Fitting", restoreText, beforeText, fitF);
         else
             addButtonDisabled(0, "Fitting", "Requires dick " + compareBy + " less than " + maxSize);
         //too big
-        if (player.findCock(1, maxSize, -1, compareBy, true) >= 0)
+        if (player.findCock(1, maxSize, -1, compareBy) >= 0)
             addButton(1, "Too big", restoreText, beforeText, nofitF);
         else
             addButtonDisabled(1, "Too big", "Requires dick " + compareBy + " greater than " + maxSize);
@@ -251,7 +251,7 @@ public class SceneHunter extends BaseContent {
                 print("Passed? Size check, but alt scene available for dicks smaller than " + bigMin + " " + compareBy);
                 bigF();
             }
-            else if (player.findCock(1, smallProvided ? smallMax : -1, bigMin, compareBy, false) >= 0) {
+            else if (player.findCock(1, smallProvided ? smallMax : -1, bigMin, compareBy) >= 0) {
                 print("Failed size check, dick must be bigger than " + bigMin + " " + compareBy);
                 if (smallProvided) print("Passed? Another size check, but alt scene available for dicks smaller than " + smallMax + " " + compareBy);
                 mediumF();
@@ -274,19 +274,19 @@ public class SceneHunter extends BaseContent {
         //medium-small
         if (smallProvided) {
             //medium cocks
-            if (player.findCock(1, smallMax, bigMin, compareBy, false) >= 0) //tentacles don't fit
+            if (player.findCock(1, smallMax, bigMin, compareBy) >= 0) //tentacles don't fit
                 addButton(1, "Medium", restoreText, beforeText, mediumF);
             else
                 addButtonDisabled(1, "Medium", "Requires dick " + compareBy + " greater than " + smallMax + " and less than " + bigMin);
             //small cocks
-            if (player.findCock(1, -1, smallMax, compareBy, false) >= 0) //tentacles don't fit
+            if (player.findCock(1, -1, smallMax, compareBy) >= 0) //tentacles don't fit
                 addButton(2, "Small", restoreText, beforeText, smallF);
             else
                 addButtonDisabled(2, "Small", "Requires dick " + compareBy + " less than " + smallMax);
         }
         else {
             //replaced "Medium" text with "Small" to avoid player confusion
-            if (player.findCock(1, -1, bigMin, compareBy, false) >= 0) //tentacles don't fit
+            if (player.findCock(1, -1, bigMin, compareBy) >= 0) //tentacles don't fit
                 addButton(1, "Small", restoreText, beforeText, mediumF);
             else
                 addButtonDisabled(1, "Small", "Requires dick " + compareBy + " less than " + bigMin);

--- a/classes/classes/Scenes/Areas/Forest/Akbal.as
+++ b/classes/classes/Scenes/Areas/Forest/Akbal.as
@@ -179,161 +179,20 @@ public class Akbal extends Monster
 
 		public function Akbal()
 		{
+			var mod:int = flags[kFLAGS.AKBAL_LVL_UP]; //just to be concise
+			var addIntWis:int = (mod <= 4) ? mod * 19 : 4*19 + (mod - 4) * 9;
 			trace("Akbal Constructor!");
-			if (flags[kFLAGS.AKBAL_LVL_UP] < 1) {
-				initStrTouSpeInte(61, 89, 75, 86);
-				initWisLibSensCor(85, 80, 50, 100);
-				this.weaponAttack = 17;
-				this.armorDef = 10;
-				this.armorMDef = 20;
-				this.bonusHP = 100;
-				this.bonusLust = 150;
-				this.level = 20;
-				this.additionalXP = 50;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 1) {
-				initStrTouSpeInte(74, 109, 90, 105);
-				initWisLibSensCor(104, 97, 60, 100);
-				this.weaponAttack = 20;
-				this.armorDef = 12;
-				this.armorMDef = 24;
-				this.bonusHP = 200;
-				this.bonusLust = 183;
-				this.level = 26;
-				this.additionalXP = 100;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 2) {
-				initStrTouSpeInte(87, 129, 105, 124);
-				initWisLibSensCor(123, 114, 70, 100);
-				this.weaponAttack = 23;
-				this.armorDef = 14;
-				this.armorMDef = 28;
-				this.bonusHP = 300;
-				this.bonusLust = 216;
-				this.level = 32;
-				this.additionalXP = 150;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 3) {
-				initStrTouSpeInte(100, 149, 120, 143);
-				initWisLibSensCor(142, 131, 80, 100);
-				this.weaponAttack = 26;
-				this.armorDef = 16;
-				this.armorMDef = 32;
-				this.bonusHP = 400;
-				this.bonusLust = 249;
-				this.level = 38;
-				this.additionalXP = 200;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 4) {
-				initStrTouSpeInte(113, 169, 135, 162);
-				initWisLibSensCor(161, 148, 90, 100);
-				this.weaponAttack = 29;
-				this.armorDef = 18;
-				this.armorMDef = 36;
-				this.bonusHP = 500;
-				this.bonusLust = 282;
-				this.level = 44;
-				this.additionalXP = 250;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 5) {
-				initStrTouSpeInte(126, 189, 150, 171);
-				initWisLibSensCor(170, 165, 100, 100);
-				this.weaponAttack = 32;
-				this.armorDef = 20;
-				this.armorMDef = 40;
-				this.bonusHP = 600;
-				this.bonusLust = 315;
-				this.level = 50;
-				this.additionalXP = 300;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 6) {
-				initStrTouSpeInte(139, 209, 165, 180);
-				initWisLibSensCor(179, 182, 110, 100);
-				this.weaponAttack = 35;
-				this.armorDef = 22;
-				this.armorMDef = 44;
-				this.bonusHP = 700;
-				this.bonusLust = 348;
-				this.level = 56;
-				this.additionalXP = 350;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 7) {
-				initStrTouSpeInte(152, 229, 180, 189);
-				initWisLibSensCor(188, 199, 120, 100);
-				this.weaponAttack = 38;
-				this.armorDef = 24;
-				this.armorMDef = 48;
-				this.bonusHP = 800;
-				this.bonusLust = 382;
-				this.level = 62;
-				this.additionalXP = 400;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 8) {
-				initStrTouSpeInte(165, 249, 195, 198);
-				initWisLibSensCor(197, 216, 130, 100);
-				this.weaponAttack = 41;
-				this.armorDef = 26;
-				this.armorMDef = 52;
-				this.bonusHP = 900;
-				this.bonusLust = 415;
-				this.level = 68;
-				this.additionalXP = 450;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 9) {
-				initStrTouSpeInte(178, 269, 210, 207);
-				initWisLibSensCor(206, 233, 140, 100);
-				this.weaponAttack = 44;
-				this.armorDef = 28;
-				this.armorMDef = 56;
-				this.bonusHP = 1000;
-				this.bonusLust = 448;
-				this.level = 74;
-				this.additionalXP = 500;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 10) {
-				initStrTouSpeInte(191, 289, 225, 216);
-				initWisLibSensCor(215, 250, 150, 100);
-				this.weaponAttack = 47;
-				this.armorDef = 30;
-				this.armorMDef = 60;
-				this.bonusHP = 1100;
-				this.bonusLust = 481;
-				this.level = 80;
-				this.additionalXP = 550;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 11) {
-				initStrTouSpeInte(204, 309, 240, 225);
-				initWisLibSensCor(224, 267, 160, 100);
-				this.weaponAttack = 50;
-				this.armorDef = 32;
-				this.armorMDef = 64;
-				this.bonusHP = 1200;
-				this.bonusLust = 514;
-				this.level = 86;
-				this.additionalXP = 600;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 12) {
-				initStrTouSpeInte(217, 329, 255, 234);
-				initWisLibSensCor(233, 284, 170, 100);
-				this.weaponAttack = 53;
-				this.armorDef = 34;
-				this.armorMDef = 68;
-				this.bonusHP = 1300;
-				this.bonusLust = 547;
-				this.level = 92;
-				this.additionalXP = 650;
-			}
-			if (flags[kFLAGS.AKBAL_LVL_UP] == 13) {
-				initStrTouSpeInte(230, 349, 270, 243);
-				initWisLibSensCor(242, 301, 180, 100);
-				this.weaponAttack = 56;
-				this.armorDef = 36;
-				this.armorMDef = 72;
-				this.bonusHP = 1400;
-				this.bonusLust = 580;
-				this.level = 98;
-				this.additionalXP = 700;
-			}//level up giving 2x all growns and so follow next level ups's as long each npc break lvl 100 (also makes npc use new better gear)
+			//New levelling
+			initStrTouSpeInte(61 + mod*13, 89 + mod*20, 75 + mod*15, 126 + addIntWis); //int might be too much, but it's scalable now
+			initWisLibSensCor(85 + addIntWis, 80 + mod*17, 50 + mod*10, 100); //wis too
+			this.weaponAttack = 17 + mod*3;
+			this.armorDef = 10 + mod*2;
+			this.armorMDef = 20 + mod*4;
+			this.bonusHP = 100 + mod*100;
+			this.bonusLust = 150 + mod*33;
+			this.level = 20 + mod*6;
+			this.additionalXP = 50 + mod*50;
+			//
 			this.a = "";
 			this.short = "Akbal";
 			this.imageName = "akbal";

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -4,11 +4,9 @@
 package classes.Scenes.Areas.Forest
 {
 import classes.*;
-import classes.BodyParts.LowerBody;
 import classes.BodyParts.Tail;
 import classes.GlobalFlags.kFLAGS;
 import classes.Items.Armors.LustyMaidensArmor;
-import classes.Items.Armors.SuccubusArmor;
 import classes.Scenes.SceneLib;
 import classes.display.SpriteDb;
 
@@ -24,57 +22,10 @@ public class AkbalScene extends BaseContent
 			if (flags[kFLAGS.SPARRABLE_NPCS_TRAINING] == 2) {
 				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] >= 1) flags[kFLAGS.AKBAL_DEFEATS_COUNTER]++;
 				else flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 1;
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 1 && flags[kFLAGS.AKBAL_LVL_UP] < 1) {
+				//level up
+				if (flags[kFLAGS.AKBAL_LVL_UP] < 13 && flags[kFLAGS.AKBAL_DEFEATS_COUNTER]  >= flags[kFLAGS.AKBAL_LVL_UP] + 1) {
 					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 1;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 2 && flags[kFLAGS.AKBAL_LVL_UP] == 1) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 2;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 3 && flags[kFLAGS.AKBAL_LVL_UP] == 2) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 3;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 4 && flags[kFLAGS.AKBAL_LVL_UP] == 3) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 4;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 5 && flags[kFLAGS.AKBAL_LVL_UP] == 4) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 5;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 6 && flags[kFLAGS.AKBAL_LVL_UP] == 5) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 6;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 7 && flags[kFLAGS.AKBAL_LVL_UP] == 6) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 7;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 8 && flags[kFLAGS.AKBAL_LVL_UP] == 7) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 8;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 9 && flags[kFLAGS.AKBAL_LVL_UP] == 8) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 9;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 10 && flags[kFLAGS.AKBAL_LVL_UP] == 9) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 10;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 11 && flags[kFLAGS.AKBAL_LVL_UP] == 10) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 11;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 12 && flags[kFLAGS.AKBAL_LVL_UP] == 11) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 12;
-				}
-				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] == 13 && flags[kFLAGS.AKBAL_LVL_UP] == 12) {
-					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
-					flags[kFLAGS.AKBAL_LVL_UP] = 13;
+					++flags[kFLAGS.AKBAL_LVL_UP];
 				}
 			}
 			if (hpVictory) {//[General Victory]
@@ -97,7 +48,6 @@ public class AkbalScene extends BaseContent
 					var vagoo:Function =null;
 					var vagooLick:Function =null;
 					var buttFuck:Function =null;
-					var bikiniTits:Function =null;
 					if (player.hasCock()) {
 						buttFuck = rapeAkbal;
 						addButton(0, "Butt-fuck", buttFuck);
@@ -126,7 +76,6 @@ public class AkbalScene extends BaseContent
 				var vagoo:Function =null;
 				var vagooLick:Function =null;
 				var buttFuck:Function =null;
-				var bikiniTits:Function =null;
 				if (player.hasCock()) {
 					buttFuck = rapeAkbal;
 				addButton(0, "Butt-fuck", buttFuck);
@@ -139,9 +88,6 @@ public class AkbalScene extends BaseContent
 			}
 				LustyMaidensArmor.addTitfuckButton(3);
 				SceneLib.uniqueSexScene.pcUSSPreChecksV2(akbalDefeated2);
-								//Rape / Don't Rape
-			//EngineCore.simpleChoices("Butt-fuck", buttFuck, "Take Vaginally", vagoo, "Force Lick", vagooLick, "B.Titfuck", bikiniTits, );
-				return;
 			}
 		}
 

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -3,698 +3,594 @@
  */
 package classes.Scenes.Areas.Forest
 {
-import classes.*;
-import classes.BodyParts.Tail;
-import classes.GlobalFlags.kFLAGS;
-import classes.Items.Armors.LustyMaidensArmor;
-import classes.Scenes.SceneLib;
-import classes.display.SpriteDb;
+	import classes.*;
+	import classes.BodyParts.Tail;
+	import classes.GlobalFlags.kFLAGS;
+	import classes.Items.Armors.LustyMaidensArmor;
+	import classes.Scenes.SceneLib;
+	import classes.display.SpriteDb;
 
-public class AkbalScene extends BaseContent
-	{
-		public function AkbalScene()
-		{
+	public class AkbalScene extends BaseContent {
+		public function AkbalScene() {
 		}
 
-		public function akbalDefeated(hpVictory:Boolean):void{
+		/**
+		 * @param hpVictory true if killed by decreasing hp
+		 * @param count true to increase defeat counters, false otherwise
+		 */
+		public function akbalDefeated(hpVictory:Boolean, count:Boolean = true):void {
+
 			flags[kFLAGS.AKBAL_SUBMISSION_STATE] = 1;
-			clearOutput();
 			if (flags[kFLAGS.SPARRABLE_NPCS_TRAINING] == 2) {
 				if (flags[kFLAGS.AKBAL_DEFEATS_COUNTER] >= 1) flags[kFLAGS.AKBAL_DEFEATS_COUNTER]++;
 				else flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 1;
 				//level up
-				if (flags[kFLAGS.AKBAL_LVL_UP] < 13 && flags[kFLAGS.AKBAL_DEFEATS_COUNTER]  >= flags[kFLAGS.AKBAL_LVL_UP] + 1) {
+				if (flags[kFLAGS.AKBAL_LVL_UP] < 13 && flags[kFLAGS.AKBAL_DEFEATS_COUNTER] >= flags[kFLAGS.AKBAL_LVL_UP] + 1) {
 					flags[kFLAGS.AKBAL_DEFEATS_COUNTER] = 0;
 					++flags[kFLAGS.AKBAL_LVL_UP];
 				}
 			}
-			if (hpVictory) {//[General Victory]
-				/*if(rand(10) == 0) {
-				   outputText("Akbal falls to the ground, but as you raise your [weapon] to deliver the final blow, a harsh ripping sound rends the air.  A dark form covered in burning violet light flies out of the jaguar's body; the demon has fled, leaving a corpse behind.  You have no doubt that the demon can gain another body, but it's best to take the old one with you to make sure it doesn't regain its form easily.");
-				   //9999 change monster name to let itemloot know what item to drop.
-				   short = "Akbitch";
-				   //[Get 'Jaguar Pelt']
-				 }*/
-				//[Common chance of dropping 'Incubus Draft', 'Smart Tea' or 'Pipe']
-				outputText("Akbal falls to the ground in a beaten bloody heap.");
+			clearOutput();
+			if (hpVictory) {
+				outputText("Akbal falls to the ground in a beaten bloody heap...");
+				sceneHunter.print("You wonder how would he look if he was aroused enough...");
 			}
 			else {//[Victory via Lust]
 				outputText("Akbal falls to the ground, unable to go on. Yet a growl still rumbles in his chest, and you quickly recognize the submissive gesture when he bows his head, his cat belly hugging the ground.  His body begins shifting, and soon he has a vaguely humanoid form. You assume this is the form he uses for sex, as his lust is out of control.\n\n");
 				menu();
-				addButton(14, "Leave", cleanupAfterCombat);
-				if (player.lust >= 33 && player.gender > 0 && flags[kFLAGS.SFW_MODE] <= 0) {
+				if (player.lust >= 33) {
 					outputText("You walk around Akbal's beaten and lust crazed form with a smile on your face. The demon's growl continues as he awaits your judgment.");
 					outputText("\n\nDo you rape him?");
-					var vagoo:Function =null;
-					var vagooLick:Function =null;
-					var buttFuck:Function =null;
-					if (player.hasCock()) {
-						buttFuck = rapeAkbal;
-						addButton(0, "Butt-fuck", buttFuck);
-					}
-					if (player.hasVagina()) {
-						vagoo = girlsRapeAkbal;
-						vagooLick = rapeAkbalForcedFemaleOral;
-						addButton(1, "Take Vaginally", vagoo);
-						addButton(2, "Force Lick", vagooLick);
-					}
-					LustyMaidensArmor.addTitfuckButton(3);
-					SceneLib.uniqueSexScene.pcUSSPreChecksV2(akbalDefeated2);
-										//Rape / Don't Rape
-					//EngineCore.simpleChoices("Butt-fuck", buttFuck, "Take Vaginally", vagoo, "Force Lick", vagooLick, "B.Titfuck", bikiniTits, );
-					return;
+					//butt
+					addButtonIfTrue(0, "Butt-fuck", rapeAkbal, "Req. a cock shorter than 20 inches, not taur/naga",
+						player.cockThatFits(20, "length") >= 0 && !player.isNaga() && !player.isTaur());
+					addButtonIfTrue(5, "Butt-fuck (N)", rapeAkbal_Naga, "Req. a cock shorter than 20 inches & naga body",
+						player.cockThatFits(20, "length") >= 0 && player.isNaga());
+					addButtonIfTrue(10, "Butt-fuck (T)", rapeAkbal_Taur, "Req. a cock shorter than 20 inches & taur body",
+						player.cockThatFits(20, "length") >= 0 && player.isTaur());
+					//vag
+					addButtonIfTrue(1, "Tail Fuck", girlsRapeAkbal_Tight, "Req. a vagina & not taur",
+						player.hasVagina() && !player.isTaur());
+					addButtonIfTrue(6, "Take Vag", girlsRapeAkbal_Loose, "Req. a vagina with capacity larger than " + monster.cockArea(0) + " & not taur",
+						player.hasVagina() && !player.isTaur() && player.vaginalCapacity() >= monster.cockArea(0));
+					addButtonIfTrue(11, "Take Vag (T)", girlsRapeAkbal_Taur, "Req. a vagina and taur body",
+						player.hasVagina() && player.isTaur());
+
+					//lick
+					addButtonIfTrue(2, "Force Lick", rapeAkbalForcedFemaleOral, "Req. a vagina, not taur/naga",
+						player.hasVagina() && !player.isNaga() && !player.isTaur());
+					addButtonIfTrue(7, "ForceLick (N)", rapeAkbalForcedFemaleOral_Naga, "Req. a vagina & naga body",
+						player.hasVagina() && player.isNaga());
+					addButtonIfTrue(12, "ForceLick (T)", rapeAkbalForcedFemaleOral_Taur, "Req. a vagina & taur body",
+						player.hasVagina() && player.isTaur());
+					LustyMaidensArmor.addTitfuckButton(4);
+					SceneLib.uniqueSexScene.pcUSSPreChecksV2(curry(akbalDefeated, false));
+					addButton(14, "Leave", cleanupAfterCombat);
 				}
-			}
-			cleanupAfterCombat();
-		}
-		public function akbalDefeated2():void {
-			menu();
-			addButton(14, "Leave", cleanupAfterCombat);
-			if (player.lust >= 33 && player.gender > 0 && flags[kFLAGS.SFW_MODE] <= 0) {
-				outputText("You walk around Akbal's beaten and lust crazed form with a smile on your face. The demon's growl continues as he awaits your judgment.");
-				outputText("\n\nDo you rape him?");
-				var vagoo:Function =null;
-				var vagooLick:Function =null;
-				var buttFuck:Function =null;
-				if (player.hasCock()) {
-					buttFuck = rapeAkbal;
-				addButton(0, "Butt-fuck", buttFuck);
+				else {
+					outputText("You're not aroused enough to rape hum");
+					cleanupAfterCombat();
 				}
-				if (player.hasVagina()) {
-					vagoo = girlsRapeAkbal;
-					vagooLick = rapeAkbalForcedFemaleOral;
-					addButton(1, "Take Vaginally", vagoo);
-					addButton(2, "Force Lick", vagooLick);
-			}
-				LustyMaidensArmor.addTitfuckButton(3);
-				SceneLib.uniqueSexScene.pcUSSPreChecksV2(akbalDefeated2);
 			}
 		}
 
-		public function akbalWon(hpVictory:Boolean,pcCameWorms:Boolean):void{
+		public function akbalWon(hpVictory:Boolean, pcCameWorms:Boolean):void {
 			flags[kFLAGS.AKBAL_SUBMISSION_STATE] = -1;
 			flags[kFLAGS.AKBAL_BITCH_Q] = 0;
 			clearOutput();
-			if(pcCameWorms){
+			if (pcCameWorms) {
 				outputText("\n\nYour foe doesn't seem disgusted enough to leave...");
 				doNext(loseToAckballllllz);
-			} else if (hpVictory) {
+			}
+			else if (hpVictory) {
 				outputText("The intense pain causes you to black out. The last thing you see is Akbal standing over you on his two hind legs, his massive cock ominously swinging between them as he watches you lose consciousness.\n\n");
-			} else {
+			}
+			else {
 				loseToAckballllllz();
 			}
 		}
 
-		//Victory/Defeat Scenes
-		private function rapeAkbalForcedFemaleOral():void
-		{
+		private function rapeAkbalForcedFemaleOral_Naga():void {
 			flags[kFLAGS.AKBAL_BITCH_Q]++;
 			clearOutput();
-			//Naga RAPPUUUUUU
-			if (player.isNaga())
-			{
-				outputText(images.showImage("akbal-deepwoods-naga-forcedfemaleoral"));
-				outputText("You slither around the demon cat's form, wrapping him up until a scared whimper rises from his chest.  You continue to tighten your coils around Akbal until he's gasping for breath.  You ask him if he's going to be a good little demon for you.  He nods.\n\n");
-				outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, allowing you a perfect view of his low hanging balls and sheath.  You reach around his fuzzy orbs and pull his swollen cock back until the jaguar demon's 15 inch pecker is visible.\n\n");
-
-				outputText("Your eyes widen as you see several wicked looking barbs around his pre-pumping slit.  Instead of trying to deal with this massive phallus that looks like it was made to punish sinners you slither around to the front of the creature.\n\n");
-
-				outputText("Your scent causes the growl ripping out of Akbal's chest to quiver.  You lay before him, reaching up to smash his furry lips into your " + vaginaDescript(0) + ".  The demon, unable to escape his debilitating arousal, begins to lap at your " + vaginaDescript(0) + ".  He shoves his face against your " + vaginaDescript(0) + " twisting his lips and drilling his tongue into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe in ecstasy.\n\n");
-
-				outputText("He begins to lift up, probably to get into position above you and sake his lust, but you force his face back down into your " + vaginaDescript(0) + ".  After dropping a line about how he has to make your cum or get his head ripped off Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
-
-				outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap on the floor.  After you've recovered you gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  Just as you begin to leave you notice a group of imps watching you and the jaguar demon, their cocks out and leaking as their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, each twirling a bottle of liquid and playing with her snatch.\n\n");
-
-				outputText("As you leave Akbal snarls as the creatures that once feared him use his overtly aroused state to get revenge on the \"god\" of the terrestrial fire.  Even after you've reached the edge of the forest the wails of the jaguar demon can still be heard but just barely over the high pitched laughter of the demon imps and goblin females.");
-			}
-			//Centaur RAPPUUUUU
-			else if (player.isTaur())
-			{
-				outputText(images.showImage("akbal-deepwoods-taur-forcedfemaleoral"));
-				outputText("You roughly grab the scruff of the demon's neck, aiming a gut crushing blow to his stomach and causing him to call out in pain.\n\n");
-
-				outputText("\"<i>Who's gonna submit now... bitch?</i>\"\n\n");
-				outputText("Akbal snarls as you shove him back first onto the forest ground.  You look down at him, fully prepared to have your way with his demon dick.  What you see causes your " + vaginaDescript(0) + " to flinch at the thought of what would have happened if you had lost and the demon had used that on you.\n\n");
-
-				outputText("The head of the massive dick sitting between Akbal's thighs is covered in a dozen tiny barbs that look like they were created to punish sinners.\n\n");
-
-				outputText("You walk around the creature, irritated at the fact that you can't squat on that crazily large demon cat dick.  Once you're on the other side of him you sit your hind quarters on his face.\n\n");
-
-				outputText("Akbal gives a muffled scream at first but soon he gets the message. His tongue slithers into your " + vaginaDescript(0) + ".  You lift yourself a little; well... you lean forward a bit to let the demon actually breath.  This proves to be the right choice as Akbal is ravenous for your " + vaginaDescript(0) + ".\n\n");
-
-				outputText("He drills his tonuge into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe in ecstasy.  He begins to lift up, probably to get the weight of your body off of the rest of his face, but you grab his tender furry balls in your hand and he stops before you're forced to do something drastic.\n\n");
-
-				outputText("After dropping a line about how he has to make you cum or get his head ripped off Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
-
-				outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap.  After you've recovered you stand and gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  Just as you begin to leave you notice a group of imps watching you and the jaguar demon, their cocks out and leaking as their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, each twirling a bottle of liquid and playing with her snatch.\n\n");
-
-				outputText("As you leave Akbal snarls as the creatures that once feared him use his overtly aroused state to get revenge on the \"god\" of the terrestrial fire.  Even after you've reached the edge of the forest the wails of the jaguar demon can still be heard but just barely over the high pitched laughter of the demon imps and goblin females.");
-			}
-			//Everybody else
-			else
-			{
-				outputText(images.showImage("akbal-deepwoods-forcedfemaleoral"));
-				outputText("You roughly grab the scruff of the demon's neck and give a gut-crushing blow to his stomach, causing him to call out in pain.");
-				outputText("\n\n\"<i>Who's gonna submit now, bitch?</i>\"\n\n");
-				outputText("Akbal grunts as you smash his face into the ground.  At your command he raises his hind quarters, allowing you a perfect view of his low-hanging balls and sheath.  You reach around his fuzzy orbs and pull his swollen cock back until the jaguar demon's 15-inch pecker is visible.\n\n");
-				outputText("Your eyes widen when you see several wicked-looking barbs around his pre-pumping cockhead.  Instead of trying to deal with this massive phallus that looks like it was made to punish sinners, you walk around to the front of the creature.\n\n");
-				outputText("Your scent causes Akbal's growling to quiver.  You lay down before him, grabbing his head and smashing his furry lips into your " + vaginaDescript(0) + ".  The demon, unable to escape his debilitating arousal, begins to lap at your " + vaginaDescript(0) + ".  He twists his lips and drills his tongue into you, mercilessly attacking your " + clitDescript() + ", and you scream, howl and cringe in ecstasy.  He begins to lift up, probably to get into position above you, but you force his face back down into your " + vaginaDescript(0) + ".  After dropping a line about how he has to make your cum or get his head ripped off, Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
-
-				outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap on the floor.  After you've recovered, you stand and gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  As you walk away, you notice a group of imps watching you and the jaguar demon with their cocks out and leaking, their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, and each is twirling a bottle of liquid while playing with her snatches.\n\n");
-				outputText("Akbal snarls as you leave, the creatures that once feared him using his aroused state to get revenge on the 'god' of the terrestrial fire.  Even after you've reached the edge of the forest, the jaguar demon's pained howls can still be heard – though, just barely over the high-pitched laughter of the demon imps and the cackling of the goblin females.");
-			}
-			//END CENTAUR STUFF
-			player.sexReward("saliva");
-			dynStats("cor+",1);
+			outputText(images.showImage("akbal-deepwoods-naga-forcedfemaleoral"));
+			outputText("You slither around the demon cat's form, wrapping him up until a scared whimper rises from his chest.  You continue to tighten your coils around Akbal until he's gasping for breath.  You ask him if he's going to be a good little demon for you.  He nods.\n\n");
+			outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, allowing you a perfect view of his low hanging balls and sheath.  You reach around his fuzzy orbs and pull his swollen cock back until the jaguar demon's 15-inch pecker is visible.\n\n");
+			outputText("Your eyes widen as you see several wicked looking barbs around his pre-pumping slit.  Instead of trying to deal with this massive phallus that looks like it was made to punish sinners you slither around to the front of the creature.\n\n");
+			outputText("Your scent causes the growl ripping out of Akbal's chest to quiver.  You lay before him, reaching up to smash his furry lips into your " + vaginaDescript(0) + ".  The demon, unable to escape his debilitating arousal, begins to lap at your " + vaginaDescript(0) + ".  He shoves his face against your " + vaginaDescript(0) + " twisting his lips and drilling his tongue into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe in ecstasy.\n\n");
+			outputText("He begins to lift up, probably to get into position above you and sake his lust, but you force his face back down into your " + vaginaDescript(0) + ".  After dropping a line about how he has to make your cum or get his head ripped off Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
+			outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap on the floor.  After you've recovered you gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  Just as you begin to leave you notice a group of imps watching you and the jaguar demon, their cocks out and leaking as their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, each twirling a bottle of liquid and playing with her snatch.\n\n");
+			outputText("As you leave Akbal snarls as the creatures that once feared him use his overtly aroused state to get revenge on the \"god\" of the terrestrial fire.  Even after you've reached the edge of the forest the wails of the jaguar demon can still be heard but just barely over the high-pitched laughter of the demon imps and goblin females.");
+			player.sexReward("saliva", "Vaginal");
+			dynStats("cor+", 1);
 			cleanupAfterCombat();
 		}
 
-		//Standard rapes - buttfucks and oral
-		private function rapeAkbal():void
-		{
+		private function rapeAkbalForcedFemaleOral_Taur():void {
 			flags[kFLAGS.AKBAL_BITCH_Q]++;
-			var primary:Number = player.cockThatFits(50);
-			if (primary < 0)
-				primary = 0;
 			clearOutput();
-			//Naga RAPPUUUUUU
-			if (player.isNaga())
-			{
-				outputText("You slither around the demon cat's form, wrapping him up until a scared whimper rises from his chest.  You continue to tighten your coils around Akbal until he's gasping for breath.  You ask him if he's going to be a good little demon for you.  He nods.\n\n");
+			outputText(images.showImage("akbal-deepwoods-taur-forcedfemaleoral"));
+			outputText("You roughly grab the scruff of the demon's neck, aiming a gut crushing blow to his stomach and causing him to call out in pain.\n\n");
+			outputText("\"<i>Who's gonna submit now... bitch?</i>\"\n\n");
+			outputText("Akbal snarls as you shove him back first onto the forest ground.  You look down at him, fully prepared to have your way with his demon dick.  What you see causes your " + vaginaDescript(0) + " to flinch at the thought of what would have happened if you had lost, and the demon had used that on you.\n\n");
+			outputText("The head of the massive dick sitting between Akbal's thighs is covered in a dozen tiny barbs that look like they were created to punish sinners.\n\n");
+			outputText("You walk around the creature, irritated at the fact that you can't squat on that crazily large demon cat dick.  Once you're on the other side of him you sit your hind quarters on his face.\n\n");
+			outputText("Akbal gives a muffled scream at first, but soon he gets the message. His tongue slithers into your " + vaginaDescript(0) + ".  You lift yourself a little; well... you lean forward a bit to let the demon actually breath.  This proves to be the right choice as Akbal is ravenous for your " + vaginaDescript(0) + ".\n\n");
+			outputText("He drills his tonuge into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe in ecstasy.  He begins to lift up, probably to get the weight of your body off of the rest of his face, but you grab his tender furry balls in your hand, and he stops before you're forced to do something drastic.\n\n");
+			outputText("After dropping a line about how he has to make you cum or get his head ripped off Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
+			outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap.  After you've recovered you stand and gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  Just as you begin to leave you notice a group of imps watching you and the jaguar demon, their cocks out and leaking as their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, each twirling a bottle of liquid and playing with her snatch.\n\n");
+			outputText("As you leave Akbal snarls as the creatures that once feared him use his overtly aroused state to get revenge on the \"god\" of the terrestrial fire.  Even after you've reached the edge of the forest the wails of the jaguar demon can still be heard but just barely over the high-pitched laughter of the demon imps and goblin females.");
+			player.sexReward("saliva", "Vaginal");
+			dynStats("cor+", 1);
+			cleanupAfterCombat();
+		}
 
-				//(If player has a dick)
-				if (player.cockTotal() > 0)
-				{
-					outputText(images.showImage("akbal-deepwoods-male-naga-rapeakbal"));
-					//(Sm Penis: 7 inches or less)
-					if (player.cocks[primary].cockLength <= 7)
-					{
-						outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  First you poke it with your finger, causing Akbal to flinch at the sensation.  Taking your " + cockDescript(primary) + " in hand you shove in without hesitation or mercy.  The virginally-tight hole clamps shut and Akbal hisses in pain as you force him open.  In no time at all you're sawing your " + cockDescript(primary) + " in and out of the demon's virginally-tight hole, relishing in the way it quivers and squirms around your embedded " + cockDescript(primary) + ".\n\n");
-					}
-					//(Md Penis: 8-12 inches)
-					else if (player.cocks[primary].cockLength <= 12)
-					{
-						outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  A light tap of your finger causes the tiny hole to constrict in fear as Akbal's entire body flinches away from you.  You grab your " + cockDescript(primary) + " with a cruel smile.\n\n");
-
-						outputText("As you shove your " + cockDescript(primary) + " into his tight pucker you are not surprised to find your " + cockDescript(primary) + " barely able to breach the tightly sealed walls.  Grunting with effort you slowly inch forward, Akbal howling and squirming beneath you as he is taken without regard for his own pleasure.\n\n");
-
-						outputText("After a dozen achingly slow thrusts Akbal's asshole begins to loosen and you begin to saw your " + cockDescript(primary) + " in and out of his pucker with force as the demon cat's howls range from pained to pleased.\n\n");
-					}
-					//(Lg Penis: 13 inches and up)
-					else
-					{
-						outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, giving you a perfect view of his tight pucker.  A short glance tells you your " + cockDescript(primary) + " won't fit... but since when has that stopped you from trying?\n\n");
-
-						outputText("When you slide a single finger against his virginally-tight hole Akbal flinches, the already tight hole clamping shut in fear.\n\n");
-
-						outputText("You twist Akbal's tail into your fist and laugh as a scared whimper rises out of the jaguar demon's throat.  You begin to push your huge cock in with one hand as your other pulls Akbal's tail.  The creature wines and howls as you invade its clenching sphincter, forcibly stretching its tight pink hole to a dangerous degree with your " + cockDescript(primary) + ".  All too soon you are halted, barely able to fit more than a foot of your huge cock into Akbal's virginally-tight hole.  Deciding that's good enough you pull out and push forward, meeting the same resistance as before.\n\n");
-
-						outputText("After hours of resistance and howling, Akbal's body shudders as his asshole relaxes due to complete exhaustion.  Battling with your tremendous cock seems to have made him almost pass out and he no longer has the energy to resist you.  The jaguar demon's body flinches with your every thrust as you begin to pound him raw, without lube and without mercy.\n\n");
-					}
-					//(transition)
-					outputText("You rape the jaguar demon's tight hole with steadily mounting force, your " + hipDescript() + " smashing into his body with freight train force and causing him to cry out.  Despite this his 15 inch swollen sex organ pumps pre beneath him, letting you know that his pain is mixed with plenty of unwilling pleasure.\n\n");
-
-					//(With Fertility/Lots of Jizz Perk)
-					if (player.cumQ() > 1000)
-					{
-						outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides.  The jaguar demon erupts as well, his body convulsing in time with your still thrusting [cock].\n\n");
-
-						outputText("As your cock continues to pump massive tons of liquid into the jaguar demon you grind your still swelling sex organ inside him and beneath the two of you his belly begins to bulge as he is filled.  As your massive orgasm subsides you pull out, releasing a gargantuan deluge of your thick spunk that rolls down his legs and creates a large puddle in the forest floor.  Akbal heaves a relieved sighs, obviously happy you are done raping him.\n\n");
-					}
-					//(without perk)
-					else
-						outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides. Beneath you Akbal's own orgasm erupts and the jaguar demon goes limp as you continue to pound him through his orgasm.  When you pull out you aim a slap at Akbal's now very tender ass, making him yelp as your unexpected blow connects.\n\n");
-
-					//(Ending)
-					outputText("As you stand you gather your [armor] and turn to leave the weakened demon behind you.  Just as you begin to walk away you notice a group of imps watching you and the jaguar demon, their cocks out and leaking.  Mixed in with the crowd are several goblins, each with a vial of liquid and a malicious grin.\n\n");
-
-					outputText("As you leave Akbal snarls as the creatures that once feared him use his weakened state to exact revenge on the \"god\" of the terrestrial fire.  Even After you've reached the edge of the forest the jaguar demon's pained snarls can still be heard but just barely over the high pitched laughter of the demon imps and the cackling of the goblin females.");
-				}
-				//(If the player has a vagina)
-				else
-				{
-					outputText(images.showImage("akbal-deepwoods-female-naga-rapeakbal"));
-					outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, allowing you a perfect view of his low hanging balls and sheath.  You reach around his fuzzy orbs and pull his swollen cock back until the jaguar demon's 15 inch pecker is visible.\n\n");
-
-					outputText("Your eyes widen as you see several wicked looking barbs around his pre-pumping slit.  Instead of trying to deal with this massive phallus that looks like it was made to punish sinners you slither around to the front of the creature.\n\n");
-
-					outputText("Your scent causes the growl ripping out of Akbal's chest to quiver.  You lay before him, reaching up to smash his furry lips into your " + vaginaDescript(0) + ".  The demon, unable to escape his debilitating arousal, begins to lap at your " + vaginaDescript(0) + ".  He shoves his face against your " + vaginaDescript(0) + " twisting his lips and drilling his tongue into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe in ecstasy.\n\n");
-
-					outputText("He begins to lift up, probably to get into position above you and sake his lust, but you force his face back down into your " + vaginaDescript(0) + ".  After dropping a line about how he has to make your cum or get his head ripped off Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
-
-					outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap on the floor.  After you've recovered you gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  Just as you begin to leave you notice a group of imps watching you and the jaguar demon, their cocks out and leaking as their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, each twirling a bottle of liquid and playing with her snatch.\n\n");
-
-					outputText("As you leave Akbal snarls as the creatures that once feared him use his overtly aroused state to get revenge on the \"god\" of the terrestrial fire.  Even after you've reached the edge of the forest the wails of the jaguar demon can still be heard but just barely over the high pitched laughter of the demon imps and goblin females.");
-				}
-				player.sexReward("Default","Dick",true,false);
-				dynStats("cor", 1);
-				cleanupAfterCombat();
-					//END NAGA STUFF
-			}
-			//Centaur RAPPUUUUU
-			else if (player.isTaur())
-			{
-				outputText("You roughly grab the scruff of the demon's neck, aiming a gut crushing blow to his stomach and causing him to call out in pain.\n\n");
-
-				outputText("\"<i>Who's gonna submit now... bitch?</i>\"\n\n");
-
-				//(If player has a dick)
-				if (player.cockTotal() > 0)
-				{
-					outputText(images.showImage("akbal-deepwoods-male-taur-rapeakbal"));
-					//(Sm Penis: 7 inches or less)
-					if (player.cocks[primary].cockLength <= 7)
-					{
-						outputText("Akbal snarls pitifully as you shove him stomach down against a log.  Your " + cockDescript(primary) + " leaks at the thought of bringing this \"god\" down a notch .  At your command he arches his back and lifts his tail, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  As you lightly tap it with your finger it flinches, becoming even tighter as Akbal's body jerks away in fear.\n\n");
-
-						outputText("You rear up, standing on hind legs for a moment before your front legs fall to the ground, Akbal's head between them with his hair tickling your belly.  You give a few experimental thrusts.  The first one causes your " + cockDescript(primary) + " to slide up Akbal's upturned cheeks, making him cringe.  The second one, however, catches.\n\n");
-
-						outputText("The virginally-tight hole clamps shut and Akbal hisses in pain as you force him open.  In no time at all you're sawing your " + cockDescript(primary) + " in and out of the demon's virginally-tight hole, relishing in the way it quivers and squirms around your embedded " + cockDescript(primary) + ".  The sounds coming from Akbal's throat are varied but include many unwillingly pleased groans.  He's obviously liking this more  than he's willing to admit.\n\n");
-					}
-					//(Md Penis: 8-12 inches)
-					else if (player.cocks[primary].cockLength <= 12)
-					{
-						outputText("Akbal snarls pitifully as you shove him stomach down against a log.  Your " + cockDescript(primary) + " leaks at the thought of bringing this \"god\" down a notch.  At your command he arches his back and lifts his tail, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  As you lightly tap it with your finger it flinches, becoming even tighter as Akbal's body jerks away in fear.\n\n");
-
-						outputText("You rear up, standing on hind legs for a moment before your front legs fall to the ground, Akbal's head between them with his hair tickling your belly.  You give a few experimental thrusts.  The first one causes your " + cockDescript(primary) + " to slide up Akbal's upturned cheeks, making him cringe.  The second one, however, catches.\n\n");
-
-						outputText("As you shove your " + cockDescript(primary) + " forward into his virginally-tight pucker you are not surprised to find your " + cockDescript(primary) + " barely able to breach the tightly sealed walls.  Grunting with effort you slowly inch forward, Akbal howling and squirming beneath you as he is taken without regard for his own pleasure.\n\n");
-
-						outputText("After a dozen achingly slow thrusts Akbal's asshole begins to loosen and you begin to saw your " + cockDescript(primary) + " in and out of his pucker.  The demon cat's howls range from pained to pleased, obviously enjoying his butt rape more than he is willing to admit.\n\n");
-					}
-					//(Lg Penis: 13 inches and up)
-					else
-					{
-						outputText("Akbal snarls pitifully as you shove him stomach down against a log. Your " + cockDescript(primary) + " leaks at the thought of bringing this \"god\" down a notch .  At your command he arches his back and lifts his tail, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  As you lightly tap it with your finger it flinches, becoming even tighter as Akbal's body jerks away in fear.  There's no way in hell your " + cockDescript(primary) + " can fit inside something so incredibly tight but... since when has that stopped you?\n\n");
-
-						outputText("You rear up, standing on hind legs for a moment before your front legs fall to the ground, Akbal's head between them with his hair tickling your belly.  You give a few experimental thrusts.  The first one causes your " + cockDescript(primary) + " to slide up Akbal's upturned cheeks, making him cringe.  The second one, however, catches.\n\n");
-
-						outputText("The demon wines and wraps his arms around your front legs, pulling himself away from the burning pressure of your " + cockDescript(primary) + ".  His voice breaks as you invade his clenching sphincter, forcibly stretching Akbal's tight pink hole to a dangerous degree.  All too soon you are halted, barely able to fit more than a foot of your huge cock into Akbal's virginally-tight hole.  Deciding that's good enough you pull out and push forward, meeting the same resistance as before.\n\n");
-
-						outputText("You grin as you realize that this may take a while...\n\n");
-
-						outputText("After hours of resistance and howling, Akbal's body shudders as his asshole relaxes due to complete exhaustion.  Battling with your tremendous cock seems to have made him almost pass out and he no longer has the energy to resist you.  The jaguar demon's body flinches with your every thrust as you begin to pound him raw, without lube and without mercy.\n\n");
-					}
-					//(transition)
-					outputText("You rape the jaguar demon's tight hole with steadily mounting force, your trunk smashing into his cringing body with freight train force and causing him to cry out in times with your grunts.  Despite this his 15 inch swollen sex organ pumps pre beneath him, letting you know that his pain is mixed with plenty of unwilling pleasure.\n\n");
-
-					//(With Fertility/Lots of Jizz Perk)
-					if (player.cumQ() > 1000)
-					{
-						outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides.  Akbal's suddenly clenching sphincter lets you know he has reached his orgasm as well.  ");
-						outputText("You continue to slide your still swollen sex organ inside his quivering hole as you pump massive tons of liquid into the false god's stomach and bowels.  Beneath the two of you his belly begins to bulge as he is filled to a dangerous degree.  ");
-						outputText("Once your massive orgasm subsides you pull out, releasing a gargantuan deluge of your thick spunk that rolls down his legs and creates a large puddle in the forest floor.  Akbal heaves a relieved sigh, obviously happy you are finally done raping him.\n\n");
-					}
-					//(without perk)
-					else
-					{
-						outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides.  Akbal's suddenly clenching sphincter lets you know he has reached his orgasm as well.  The jaguar demon's body goes limp as you continue to pound him through his orgasm.  When you pull out you aim a slap at Akbal's now very tender ass, making him yelp as your unexpected blow connects.\n\n");
-					}
-					//(Ending)
-					outputText("As you stand you gather your [armor] and turn to leave the weakened demon behind you.  Just as you begin to walk away you notice a group of imps watching you and the jaguar demon, their cocks out and leaking.  Mixed in with the crowd are several goblins, each with a vial of liquid and a malicious grin.\n\n");
-					outputText("As you leave Akbal snarls as the creatures that once feared him use his weakened state to exact revenge on the \"god\" of the terrestrial fire.  Even After you've reached the edge of the forest the jaguar demon's pained snarls can still be heard but just barely over the high pitched laughter of the demon imps and the cackling of the goblin females.\n\n");
-				}
-				//(If the player has a vagina)
-				else
-				{
-					outputText(images.showImage("akbal-deepwoods-female-taur-rapeakbal"));
-					outputText("Akbal snarls as you shove him back first onto the forest ground.  You look down at him, fully prepared to have your way with his demon dick.  What you see causes your " + vaginaDescript(0) + " to flinch at the thought of what would have happened if you had lost and the demon had used that on you.\n\n");
-
-					outputText("The head of the massive dick sitting between Akbal's thighs is covered in a dozen tiny barbs that look like they were created to punish sinners.\n\n");
-
-					outputText("You walk around the creature, irritated at the fact that you can't squat on that crazily large demon cat dick.  Once you're on the other side of him you sit your hind quarters on his face.\n\n");
-
-					outputText("Akbal gives a muffled scream at first but soon he gets the message. His tongue slithers into your " + vaginaDescript(0) + ".  You lift yourself a little; well... you lean forward a bit to let the demon actually breath.  This proves to be the right choice as Akbal is ravenous for your " + vaginaDescript(0) + ".\n\n");
-
-					outputText("He drills his tonuge into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe in ecstasy.  He begins to lift up, probably to get the weight of your body off of the rest of his face, but you grab his tender furry balls in your hand and he stops before you're forced to do something drastic.\n\n");
-
-					outputText("After dropping a line about how he has to make you cum or get his head ripped off Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
-
-					outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap.  After you've recovered you stand and gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  Just as you begin to leave you notice a group of imps watching you and the jaguar demon, their cocks out and leaking as their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, each twirling a bottle of liquid and playing with her snatch.\n\n");
-
-					outputText("As you leave Akbal snarls as the creatures that once feared him use his overtly aroused state to get revenge on the \"god\" of the terrestrial fire.  Even after you've reached the edge of the forest the wails of the jaguar demon can still be heard but just barely over the high pitched laughter of the demon imps and goblin females.");
-				}
-				player.sexReward("Default","Dick",true,false);
-				dynStats("cor", 1);
-				cleanupAfterCombat();
-				return;
-					//END CENTAUR STUFF
-			}
+		private function rapeAkbalForcedFemaleOral():void {
+			flags[kFLAGS.AKBAL_BITCH_Q]++;
+			clearOutput();
+			outputText(images.showImage("akbal-deepwoods-forcedfemaleoral"));
 			outputText("You roughly grab the scruff of the demon's neck and give a gut-crushing blow to his stomach, causing him to call out in pain.");
 			outputText("\n\n\"<i>Who's gonna submit now, bitch?</i>\"\n\n");
-			//[Player has a dick]
-			if (player.cockTotal() > 0)
-			{
-				outputText(images.showImage("akbal-deepwoods-male-rapeakbal"));
-				outputText("Akbal grunts as you smash his face into the ground.  At your command he raises his hind quarters, allowing you a perfect view of his tight pucker.  From the looks of it, his tightly sealed rim would look at home on a virgin.\n\n");
+			outputText("Akbal grunts as you smash his face into the ground.  At your command he raises his hind quarters, allowing you a perfect view of his low-hanging balls and sheath.  You reach around his fuzzy orbs and pull his swollen cock back until the jaguar demon's 15-inch pecker is visible.\n\n");
+			outputText("Your eyes widen when you see several wicked-looking barbs around his pre-pumping cockhead.  Instead of trying to deal with this massive phallus that looks like it was made to punish sinners, you walk around to the front of the creature.\n\n");
+			outputText("Your scent causes Akbal's growling to quiver.  You lay down before him, grabbing his head and smashing his furry lips into your " + vaginaDescript(0) + ".  The demon, unable to escape his debilitating arousal, begins to lap at your " + vaginaDescript(0) + ".  He twists his lips and drills his tongue into you, mercilessly attacking your " + clitDescript() + ", and you scream, howl and cringe in ecstasy.  He begins to lift up, probably to get into position above you, but you force his face back down into your " + vaginaDescript(0) + ".  After dropping a line about how he has to make your cum or get his head ripped off, Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
+			outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap on the floor.  After you've recovered, you stand and gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  As you walk away, you notice a group of imps watching you and the jaguar demon with their cocks out and leaking, their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, and each is twirling a bottle of liquid while playing with her snatches.\n\n");
+			outputText("Akbal snarls as you leave, the creatures that once feared him using his aroused state to get revenge on the 'god' of the terrestrial fire.  Even after you've reached the edge of the forest, the jaguar demon's pained howls can still be heard – though, just barely over the high-pitched laughter of the demon imps and the cackling of the goblin females.");
+			player.sexReward("saliva", "Vaginal");
+			dynStats("cor+", 1);
+			cleanupAfterCombat();
+		}
+
+		private function rapeAkbal_Naga():void {
+			flags[kFLAGS.AKBAL_BITCH_Q]++;
+			clearOutput();
+			outputText("You slither around the demon cat's form, wrapping him up until a scared whimper rises from his chest.  You continue to tighten your coils around Akbal until he's gasping for breath.  You ask him if he's going to be a good little demon for you.  He nods.\n\n");
+			outputText(images.showImage("akbal-deepwoods-male-naga-rapeakbal"));
+			sceneHunter.callBigSmall(scene, 12, 7, "length", 20);
+
+			//============================================================
+			function scene(primary:int):void {
+				if (player.cocks[primary].cockLength < 7) {
+					outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  First you poke it with your finger, causing Akbal to flinch at the sensation.  Taking your " + cockDescript(primary) + " in hand, you shove in without hesitation or mercy.  The virginally-tight hole clamps shut and Akbal hisses in pain as you force him open.  In no time at all you're sawing your " + cockDescript(primary) + " in and out of the demon's virginally-tight hole, relishing in the way it quivers and squirms around your embedded " + cockDescript(primary) + ".\n\n");
+				}
+				//(Md Penis: 8-12 inches)
+				else if (player.cocks[primary].cockLength < 12) {
+					outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  A light tap of your finger causes the tiny hole to constrict in fear as Akbal's entire body flinches away from you.  You grab your " + cockDescript(primary) + " with a cruel smile.\n\n");
+					outputText("As you shove your " + cockDescript(primary) + " into his tight pucker you are not surprised to find your " + cockDescript(primary) + " barely able to breach the tightly sealed walls.  Grunting with effort you slowly inch forward, Akbal howling and squirming beneath you as he is taken without regard for his own pleasure.\n\n");
+					outputText("After a dozen achingly slow thrusts Akbal's asshole begins to loosen, and you begin to saw your " + cockDescript(primary) + " in and out of his pucker with force as the demon cat's howls range from pained to pleased.\n\n");
+				}
+				//(Lg Penis: 13 inches and up)
+				else {
+					outputText("As you uncoil you can't help but bump into the slimy leaking faucet Akbal calls his dick.  At your command he raises his hind quarters, giving you a perfect view of his tight pucker.  A short glance tells you your " + cockDescript(primary) + " won't fit... but since when has that stopped you from trying?\n\n");
+					outputText("When you slide a single finger against his virginally-tight hole Akbal flinches, the already tight hole clamping shut in fear.\n\n");
+					outputText("You twist Akbal's tail into your fist and laugh as a scared whimper rises out of the jaguar demon's throat.  You begin to push your huge cock in with one hand as your other pulls Akbal's tail.  The creature wines and howls as you invade its clenching sphincter, forcibly stretching its tight pink hole to a dangerous degree with your " + cockDescript(primary) + ".  All too soon you are halted, barely able to fit more than a foot of your huge cock into Akbal's virginally-tight hole.  Deciding that's good enough you pull out and push forward, meeting the same resistance as before.\n\n");
+					outputText("After hours of resistance and howling, Akbal's body shudders as his asshole relaxes due to complete exhaustion.  Battling with your tremendous cock seems to have made him almost pass out, and he no longer has the energy to resist you.  The jaguar demon's body flinches with your every thrust as you begin to pound him raw, without lube and without mercy.\n\n");
+				}
+				//(transition)
+				outputText("You rape the jaguar demon's tight hole with steadily mounting force, your " + hipDescript() + " smashing into his body with freight train force and causing him to cry out.  Despite this his 15 inch swollen sex organ pumps pre beneath him, letting you know that his pain is mixed with plenty of unwilling pleasure.\n\n");
+				//(With Fertility/Lots of Jizz Perk)
+				if (player.cumQ() > 1000) {
+					outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides.  The jaguar demon erupts as well, his body convulsing in time with your still thrusting " + cockDescript(primary) + ".\n\n");
+					outputText("As your cock continues to pump massive tons of liquid into the jaguar demon you grind your still swelling sex organ inside him and beneath the two of you his belly begins to bulge as he is filled.  As your massive orgasm subsides you pull out, releasing a gargantuan deluge of your thick spunk that rolls down his legs and creates a large puddle in the forest floor.  Akbal heaves a relieved sighs, obviously happy you are done raping him.\n\n");
+				}
+				//(without perk)
+				else
+					outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides. Beneath you Akbal's own orgasm erupts, and the jaguar demon goes limp as you continue to pound him through his orgasm.  When you pull out you aim a slap at Akbal's now very tender ass, making him yelp as your unexpected blow connects.\n\n");
+				//(Ending)
+				outputText("As you stand you gather your [armor] and turn to leave the weakened demon behind you.  Just as you begin to walk away you notice a group of imps watching you and the jaguar demon, their cocks out and leaking.  Mixed in with the crowd are several goblins, each with a vial of liquid and a malicious grin.\n\n");
+				outputText("As you leave Akbal snarls as the creatures that once feared him use his weakened state to exact revenge on the \"god\" of the terrestrial fire.  Even After you've reached the edge of the forest the jaguar demon's pained snarls can still be heard but just barely over the high-pitched laughter of the demon imps and the cackling of the goblin females.");
+
+				player.sexReward("Default", "Dick", true, false);
+				dynStats("cor", 1);
+				cleanupAfterCombat();
+			}
+		}
+
+		private function rapeAkbal_Taur():void {
+			flags[kFLAGS.AKBAL_BITCH_Q]++;
+			clearOutput();
+			outputText("You roughly grab the scruff of the demon's neck, aiming a gut crushing blow to his stomach and causing him to call out in pain.\n\n");
+			outputText("\"<i>Who's gonna submit now... bitch?</i>\"\n\n");
+			outputText(images.showImage("akbal-deepwoods-male-taur-rapeakbal"));
+			sceneHunter.callBigSmall(scene, 12, 7, "length", 20);
+
+			//==================================================================
+			function scene(primary:int):void {
+				//(Sm Penis: 7 inches or less)
+				if (player.cocks[primary].cockLength < 7) {
+					outputText("Akbal snarls pitifully as you shove him stomach down against a log.  Your " + cockDescript(primary) + " leaks at the thought of bringing this \"god\" down a notch .  At your command he arches his back and lifts his tail, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  As you lightly tap it with your finger it flinches, becoming even tighter as Akbal's body jerks away in fear.\n\n");
+
+					outputText("You rear up, standing on hind legs for a moment before your front legs fall to the ground, Akbal's head between them with his hair tickling your belly.  You give a few experimental thrusts.  The first one causes your " + cockDescript(primary) + " to slide up Akbal's upturned cheeks, making him cringe.  The second one, however, catches.\n\n");
+
+					outputText("The virginally-tight hole clamps shut and Akbal hisses in pain as you force him open.  In no time at all you're sawing your " + cockDescript(primary) + " in and out of the demon's virginally-tight hole, relishing in the way it quivers and squirms around your embedded " + cockDescript(primary) + ".  The sounds coming from Akbal's throat are varied but include many unwillingly pleased groans.  He's obviously liking this more  than he's willing to admit.\n\n");
+				}
+				//(Md Penis: 8-12 inches)
+				else if (player.cocks[primary].cockLength < 12) {
+					outputText("Akbal snarls pitifully as you shove him stomach down against a log.  Your " + cockDescript(primary) + " leaks at the thought of bringing this \"god\" down a notch.  At your command he arches his back and lifts his tail, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  As you lightly tap it with your finger it flinches, becoming even tighter as Akbal's body jerks away in fear.\n\n");
+
+					outputText("You rear up, standing on hind legs for a moment before your front legs fall to the ground, Akbal's head between them with his hair tickling your belly.  You give a few experimental thrusts.  The first one causes your " + cockDescript(primary) + " to slide up Akbal's upturned cheeks, making him cringe.  The second one, however, catches.\n\n");
+
+					outputText("As you shove your " + cockDescript(primary) + " forward into his virginally-tight pucker you are not surprised to find your " + cockDescript(primary) + " barely able to breach the tightly sealed walls.  Grunting with effort you slowly inch forward, Akbal howling and squirming beneath you as he is taken without regard for his own pleasure.\n\n");
+
+					outputText("After a dozen achingly slow thrusts Akbal's asshole begins to loosen, and you begin to saw your " + cockDescript(primary) + " in and out of his pucker.  The demon cat's howls range from pained to pleased, obviously enjoying his butt rape more than he is willing to admit.\n\n");
+				}
+				//(Lg Penis: 13 inches and up)
+				else {
+					outputText("Akbal snarls pitifully as you shove him stomach down against a log. Your " + cockDescript(primary) + " leaks at the thought of bringing this \"god\" down a notch .  At your command he arches his back and lifts his tail, giving you a perfect view of his tight pucker.  From the looks of it nothing has ever even touched the tightly sealed rim.  As you lightly tap it with your finger it flinches, becoming even tighter as Akbal's body jerks away in fear.  There's no way in hell your " + cockDescript(primary) + " can fit inside something so incredibly tight but... since when has that stopped you?\n\n");
+
+					outputText("You rear up, standing on hind legs for a moment before your front legs fall to the ground, Akbal's head between them with his hair tickling your belly.  You give a few experimental thrusts.  The first one causes your " + cockDescript(primary) + " to slide up Akbal's upturned cheeks, making him cringe.  The second one, however, catches.\n\n");
+
+					outputText("The demon wines and wraps his arms around your front legs, pulling himself away from the burning pressure of your " + cockDescript(primary) + ".  His voice breaks as you invade his clenching sphincter, forcibly stretching Akbal's tight pink hole to a dangerous degree.  All too soon you are halted, barely able to fit more than a foot of your huge cock into Akbal's virginally-tight hole.  Deciding that's good enough you pull out and push forward, meeting the same resistance as before.\n\n");
+
+					outputText("You grin as you realize that this may take a while...\n\n");
+
+					outputText("After hours of resistance and howling, Akbal's body shudders as his asshole relaxes due to complete exhaustion.  Battling with your tremendous cock seems to have made him almost pass out, and he no longer has the energy to resist you.  The jaguar demon's body flinches with your every thrust as you begin to pound him raw, without lube and without mercy.\n\n");
+				}
+				//(transition)
+				outputText("You rape the jaguar demon's tight hole with steadily mounting force, your trunk smashing into his cringing body with freight train force and causing him to cry out in times with your grunts.  Despite this his 15 inch swollen sex organ pumps pre beneath him, letting you know that his pain is mixed with plenty of unwilling pleasure.\n\n");
+
+				//(With Fertility/Lots of Jizz Perk)
+				if (player.cumQ() > 1000) {
+					outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides.  Akbal's suddenly clenching sphincter lets you know he has reached his orgasm as well.  ");
+					outputText("You continue to slide your still swollen sex organ inside his quivering hole as you pump massive tons of liquid into the false god's stomach and bowels.  Beneath the two of you his belly begins to bulge as he is filled to a dangerous degree.  ");
+					outputText("Once your massive orgasm subsides you pull out, releasing a gargantuan deluge of your thick spunk that rolls down his legs and creates a large puddle in the forest floor.  Akbal heaves a relieved sigh, obviously happy you are finally done raping him.\n\n");
+				}
+				//(without perk)
+				else {
+					outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge and with a titanic howl you begin hosing down his insides.  Akbal's suddenly clenching sphincter lets you know he has reached his orgasm as well.  The jaguar demon's body goes limp as you continue to pound him through his orgasm.  When you pull out you aim a slap at Akbal's now very tender ass, making him yelp as your unexpected blow connects.\n\n");
+				}
+				//(Ending)
+				outputText("As you stand you gather your [armor] and turn to leave the weakened demon behind you.  Just as you begin to walk away you notice a group of imps watching you and the jaguar demon, their cocks out and leaking.  Mixed in with the crowd are several goblins, each with a vial of liquid and a malicious grin.\n\n");
+				outputText("As you leave Akbal snarls as the creatures that once feared him use his weakened state to exact revenge on the \"god\" of the terrestrial fire.  Even After you've reached the edge of the forest the jaguar demon's pained snarls can still be heard but just barely over the high-pitched laughter of the demon imps and the cackling of the goblin females.\n\n");
+
+				player.sexReward("Default", "Dick", true, false);
+				dynStats("cor", 1);
+				cleanupAfterCombat();
+			}
+		}
+
+		private function rapeAkbal():void {
+			flags[kFLAGS.AKBAL_BITCH_Q]++;
+			clearOutput();
+			outputText("You roughly grab the scruff of the demon's neck and give a gut-crushing blow to his stomach, causing him to call out in pain.");
+			outputText("\n\n\"<i>Who's gonna submit now, bitch?</i>\"\n\n");
+
+			outputText(images.showImage("akbal-deepwoods-male-rapeakbal"));
+			outputText("Akbal grunts as you smash his face into the ground.  At your command he raises his hind quarters, allowing you a perfect view of his tight pucker.  From the looks of it, his tightly sealed rim would look at home on a virgin.\n\n");
+			sceneHunter.callBigSmall(scene, 12, 7, "length", 20);
+
+			//==================================================================
+			function scene(primary:int):void {
 				//[Small penis (7 inches or less)]
-				if (player.biggestCockArea() < 13)
-				{
-					outputText("You first poke it with your finger, causing Akbal to flinch at the sensation.  Taking your [cock] in hand, you shove it in without hesitation or mercy.  The virgin-like hole clamps shut and Akbal hisses in pain as you force him open.  In no time at all you're sawing your [cock] in and out of the demon's tight hole, relishing in the way it quivers and squirms around your embedded [cock].\n\n");
+				if (player.cocks[primary].cockLength < 7) {
+					outputText("You first poke it with your finger, causing Akbal to flinch at the sensation.  Taking your " + cockDescript(primary) + " in hand, you shove it in without hesitation or mercy.  The virgin-like hole clamps shut and Akbal hisses in pain as you force him open.  In no time at all you're sawing your " + cockDescript(primary) + " in and out of the demon's tight hole, relishing in the way it quivers and squirms around your embedded " + cockDescript(primary) + ".\n\n");
 				}
 				//[Medium penis (8-12 inches)]
-				else if (player.biggestCockArea() < 25)
-				{
-					outputText("A light tap of your finger causes the tiny hole to constrict and Akbal's entire body flinches in fear.  You grab your [cock] with a cruel smile.  As you shove yourself into his tight pucker, you aren't surprised to find that your [cock] is barely able to breach the tightly sealed walls.  Grunting with effort you slowly inch forward, Akbal howling and squirming beneath you as he is taken without regard for his own pleasure.\n\n");
-					outputText("After a dozen achingly slow thrusts, Akbal's asshole begins to loosen and you start sawing your [cock] in and out of his pucker with force. The demon cat's howls fluctuate between yelps of pain and moans of pleasure.\n\n");
+				else if (player.cocks[primary].cockLength < 12) {
+					outputText("A light tap of your finger causes the tiny hole to constrict and Akbal's entire body flinches in fear.  You grab your " + cockDescript(primary) + " with a cruel smile.  As you shove yourself into his tight pucker, you aren't surprised to find that your " + cockDescript(primary) + " is barely able to breach the tightly sealed walls.  Grunting with effort you slowly inch forward, Akbal howling and squirming beneath you as he is taken without regard for his own pleasure.\n\n");
+					outputText("After a dozen achingly slow thrusts, Akbal's asshole begins to loosen, and you start sawing your " + cockDescript(primary) + " in and out of his pucker with force. The demon cat's howls fluctuate between yelps of pain and moans of pleasure.\n\n");
 				}
 				//[Large penis (13 inches and up)]
-				else
-				{
-					outputText("A single look tells you your [cock] won't fit... but since when has that stopped you from trying?  You slide a single finger against the virginally-tight hole and Akbal flinches. His already tight hole clamps shut in fear, as if doing so will somehow stop the inevitable intrusion.\n\n");
-					outputText("You twist Akbal's tail into your fist and laugh as a scared whimper escapes from the jaguar demon's throat.  You begin to push your [cock] in with one hand as you pull Akbal's tail with the other.  The demon whines and howls as you invade his clenching sphincter, forcibly stretching the tight pink hole to a dangerous degree.  You are halted all too soon, barely able to fit more than a foot of your [cock] into Akbal's virginally-tight hole.  Deciding that's good enough, you pull out before pushing forward again, meeting the same resistance as before.\n\n");
-					outputText("After what seems like hours of resistance and howling, Akbal's body shudders and his asshole relaxes from complete exhaustion.  Battling with your [cock] seems to have nearly made him pass out, and he no longer has the energy to resist you.  The jaguar demon's body flinches with your every thrust as you pound him raw – without lube, and without mercy.\n\n");
+				else {
+					outputText("A single look tells you your " + cockDescript(primary) + " won't fit... but since when has that stopped you from trying?  You slide a single finger against the virginally-tight hole and Akbal flinches. His already tight hole clamps shut in fear, as if doing so will somehow stop the inevitable intrusion.\n\n");
+					outputText("You twist Akbal's tail into your fist and laugh as a scared whimper escapes from the jaguar demon's throat.  You begin to push your " + cockDescript(primary) + " in with one hand as you pull Akbal's tail with the other.  The demon whines and howls as you invade his clenching sphincter, forcibly stretching the tight pink hole to a dangerous degree.  You are halted all too soon, barely able to fit more than a foot of your " + cockDescript(primary) + " into Akbal's virginally-tight hole.  Deciding that's good enough, you pull out before pushing forward again, meeting the same resistance as before.\n\n");
+					outputText("After what seems like hours of resistance and howling, Akbal's body shudders, and his asshole relaxes from complete exhaustion.  Battling with your " + cockDescript(primary) + " seems to have nearly made him pass out, and he no longer has the energy to resist you.  The jaguar demon's body flinches with your every thrust as you pound him raw – without lube, and without mercy.\n\n");
 				}
 				outputText("You rape the jaguar demon's tight hole with steadily mounting force, your " + hipDescript() + " smashing into his body with freight-train force, and causing him to cry out.  Despite this, his 15-inch swollen sex organ is pumping out pre beneath him, letting you know that his pain is mixed with plenty of unwilling pleasure.\n\n");
 				outputText("The crushing tightness of Akbal's quivering hole pushes you over the edge, and with a titanic howl you unleash your load inside him.  Akbal's suddenly clenching sphincter lets you know that he has reached his orgasm as well.\n\n");
 
 				//[With Fertility/Lots of Jizz Perk]
-				if (player.cumQ() > 1000)
-				{
-					outputText("You continue to slide your still-swollen [cock] inside his quivering hole as you pump massive tons of liquid into the false god's stomach and bowels.  Beneath the two of you, his belly begins to bulge as he is filled to a dangerous degree.\n\n");
+				if (player.cumQ() > 1000) {
+					outputText("You continue to slide your still-swollen " + cockDescript(primary) + " inside his quivering hole as you pump massive tons of liquid into the false god's stomach and bowels.  Beneath the two of you, his belly begins to bulge as he is filled to a dangerous degree.\n\n");
 					outputText("Once your massive orgasm subsides you pull out, releasing a gargantuan deluge of your thick spunk that rolls down his legs, creating a large puddle in the forest floor.  Akbal heaves a relieved sigh, obviously glad that you are finally done raping him.\n\n");
 				}
 				//[Without Fertility/Lots of Jizz Perk]
-				else
-				{
+				else {
 					outputText("The jaguar demon's body goes limp as you continue to pound him through his orgasm.  When you finally pull out, you aim a slap at Akbal's now very tender ass and make him yelp when your unexpected blow connects.\n\n");
 				}
 				outputText("Standing up, you gather your [armor] and turn to leave the weakened demon behind you.  As you walk away, you notice a group of imps watching you and the jaguar demon with their cocks out and leaking.  Mixed in with the crowd are several goblins, each with a vial of liquid and a malicious grin.\n\n");
 				outputText("Akbal snarls as you leave, the creatures that once feared him using his weakened state to get revenge on the 'god' of the terrestrial fire.  Even after you've reached the edge of the forest, the jaguar demon's pained howls can still be heard – though, just barely over the high-pitched laughter of the demon imps and the cackling of the goblin females.");
-			}
-			//[Player has a vagina]
-			else if (player.hasVagina())
-			{
-				outputText(images.showImage("akbal-deepwoods-female-rapeakbal"));
-				outputText("Akbal grunts as you smash his face into the ground.  At your command he raises his hind quarters, allowing you a perfect view of his low-hanging balls and sheath.  You reach around his fuzzy orbs and pull his swollen cock back until the jaguar demon's 15-inch pecker is visible.\n\n");
-				outputText("Your eyes widen when you see several wicked-looking barbs around his pre-pumping cockhead.  Instead of trying to deal with this massive phallus that looks like it was made to punish sinners, you walk around to the front of the creature.\n\n");
-				outputText("Your scent causes Akbal's growling to quiver.  You lay down before him, grabbing his head and smashing his furry lips into your " + vaginaDescript(0) + ".  The demon, unable to escape his debilitating arousal, begins to lap at your " + vaginaDescript(0) + ".  He twists his lips and drills his tongue into you, mercilessly attacking your " + clitDescript() + ", and you scream, howl and cringe in ecstasy.  He begins to lift up, probably to get into position above you, but you force his face back down into your " + vaginaDescript(0) + ".  After dropping a line about how he has to make your cum or get his head ripped off, Akbal whines, obviously distressed at not being able to slip his aching member into your " + vaginaDescript(0) + ".\n\n");
 
-				outputText("With a sadistic laugh you ride out your orgasm until you're reduced to a shuddering heap on the floor.  After you've recovered, you stand and gather your [armor], leaving Akbal in a groaning mess behind you.  He howls as he claws the ground, his barbed cock still rock hard beneath him.  As you walk away, you notice a group of imps watching you and the jaguar demon with their cocks out and leaking, their jagged teeth spread into feral grins.  You even spy a few goblins mixed in the crowd, and each is twirling a bottle of liquid while playing with their snatches.\n\n");
-				outputText("Akbal snarls as you leave, the creatures that once feared him using his aroused state to get revenge on the 'god' of the terrestrial fire.  Even after you've reached the edge of the forest, the jaguar demon's pained howls can still be heard – though, just barely over the high-pitched laughter of the demon imps and the cackling of the goblin females.");
+				player.sexReward("Default", "Dick", true, false);
+				dynStats("cor", 1);
+				cleanupAfterCombat();
+
+				player.sexReward("Default", "Dick", true, false);
+				dynStats("cor", 1);
+				cleanupAfterCombat();
 			}
-			player.sexReward("Default","Dick",true,false);
+		}
+
+		private function grA_start():void {
+			flags[kFLAGS.AKBAL_BITCH_Q]++;
+			clearOutput();
+			outputText("You smirk to yourself quietly as the so called \"God of Terrestrial Fire\" lays in a twitching heap on the ground, his flesh squirming as he shifts into his more humanoid form. Removing your [armor], your hand lowers to your feminine slit, pondering how to make use of him.\n\n");
+			outputText(images.showImage("akbal-deepwoods-female-bindakbal"));
+		}
+
+		private function girlsRapeAkbal_Taur():void {
+			grA_start();
+			outputText("Already you can see the trouble of trying to accommodate someone with your body type, but as they said in your village, \"<i>where there's a will, there's a way</i>\". Grabbing some of the vines from the nearby trees, you approach the nearly comatose Akbal and sling him over your back, grinning as you work through the details in your mind.\n\n");
+			outputText("Before the feline demon can recover and protest, you bind his arms to the end of the longest vines, throwing them over some of the stronger branches to make a makeshift pulley system. Hauling him up against the bark of the tree, he stirs slightly, but is still unable to work up the strength to fight back. Making the most of the time you figure you have left before he fully awakens, you bind his feet near the base of the tree, effectively turning him into a mounted toy for you to impale your " + vaginaDescript() + " upon.\n\n");
+			outputText("With his arms and legs bound, you take the time to examine your prize, reaching forward to stroke his full, baseball sized sack and swinging barbed shaft. It looks that despite the fact that you beat him into submission, the demon isn't totally opposed to the idea as he stirs to life in your hand, throbbing slightly. The jaguar starts to open his emerald eyes and glares at you, but nonetheless tries to push his hips forward, giving a snarl of annoyance when he can't work get proper leverage on the tree thanks to your binding.\n\n");
+			outputText("Keeping the vines holding his arms up in hand, you slowly turn around and lift your tail, allowing your sopping mare cunt to wink at Akbal");
+			if (player.hasCock())
+				outputText(" " + sMultiCockDesc() + " hanging beneath, twitching in anticipation");
+			outputText(". With a smirk at the helpless Gods expense, you take a step back, lining up before pushing yourself against him roughly, shoving his barbed feline shaft deeply into you.");
+			doNext(girlsRapeAkbalPart2_Taur);
+		}
+
+		private function girlsRapeAkbal_Tight():void {
+			grA_start();
+			sceneHunter.print("Fork: loose vagina or not.");
+			sceneHunter.print("Goo, Naga small checks.");
+			outputText("Rolling him over onto his back with your foot, you ");
+			if (player.vaginalCapacity() < monster.cockArea(0))
+				outputText("tsk in annoyance, knowing that you won't be able to fit his large kitty-cock between your legs without some considerable pain");
+			else
+				outputText("observe the defeated 'God'. Giving his dick a free pass to your pussy would be too big of a service, and");
+			outputText(", and you don't really trust the demon to let his mouth, with all those oh-so-sharp teeth, near your most sensitive areas. Thankfully, another option is available, currently twitching around your feet.\n\n");
+
+			outputText("Reaching down, you grab his flicking tail, ignoring his feline yowl of discomfort, stroking the spotted, silky smooth fur with a few fingers, the sensation creating shivers of lust up your spine. Already images bloom in your mind, creating all kinds of acts you could use this appendage for and plucking the most prominent one from your mind, you grab the demon cat by the scruff of his neck, ");
+			//({If strength >60}
+			if (player.str > 60)
+				outputText("hauling him towards a tree like a newborn kitten");
+			else
+				outputText("dragging him towards the nearest tree");
+			outputText(" and forcing him to lean back against it.\n\n");
+
+			outputText("Gripping his tail once more, you grab him by the fur of his head and yank him down to meet the tip, pressing insistently against his lips. Even in his weakened state Akbal refuses until you happen to glance down between his legs. It seems like the demon is more turned on by you taking charge than he would like to admit.  ");
+			//({if Naga}
+			if (player.isNaga())
+				outputText("You curl the tip of your tail around his length, catching the barbs lightly on your scales and squeezing, coaxing a low yowl of pleasure, which you hurriedly make use of, ");
+			//{If Goo}
+			else if (player.isGoo())
+				outputText("You focus, extending a small part of your liquid-like body, enveloping his feline meat in yourself, careful to avoid the tip. The sensation of damp warmth around his feline member is too much, making him open his mouth in a silent moan, which you hastily use, ");
+			else
+				outputText("Lifting up your [leg], you firmly place the sole of your foot against his barbed flesh, pressing it against his stomach, forcing the jaguar to let out a low moan, which you quickly take advantage of, ");
+
+			outputText("stuffing his own tail into his maw.  As he tries to push his tail back out, you remove your [foot] pointedly, staring down at the demon. Lifting his hips back up weakly towards you, he meekly begins to suckle on his own appendage, closing his vibrant emerald eyes as you return your attention to his shaft.\n\n");
+			dynStats("lus", 50);
+			doNext(girlsRapeAkbalPart2_Tight);
+		}
+
+		private function girlsRapeAkbal_Loose():void {
+			grA_start();
+			sceneHunter.print("Fork: loose vagina or not.");
+			sceneHunter.print("Goo, Naga small checks.");
+			outputText("You grin as you flip him over onto his back, staring down at his breeding tool between his legs, firmly erect as it rests on his rather full set of balls. Quite clearly, this \"<i>God</i>\" hasn't had much action for quite some time, hence his aggressive nature towards you. You finger yourself slightly as you examine his feline shaft, coated with layers of barbs that look as though they would be quite painful. Leaning down, you run your fingers over them, smirking as they bend slightly. They may not be enough to harm you, but sex would definitely be unpleasant... unless you happened to have a source of suitable lube nearby.\n\n");
+			outputText("Remembering the cats back home");
+			//({If player has the flexibility Perk}
+			if (player.hasPerk(PerkLib.Flexibility))
+				outputText(" and your own experience with such matters");
+			outputText(", you figure you have a pretty good idea where a reliable source of lube could be. You grin as you grab the demon cat by the scruff of his neck, ");
+			//({If strength >60}
+			if (player.str > 60)
+				outputText("hauling him towards a tree like a newborn kitten");
+			else
+				outputText("dragging him towards the nearest tree");
+			outputText(" and forcing him to lean back against it.\n\n");
+
+			outputText("In his dazed state, Akbal offers little resistance when you position him against the tree. That changes however, when you grab the hair of his head and push him down towards his own straining cock. Angry whispers flit at the edge of your mind, easily brushed aside as you reach down and squeeze the demon's cheeks, forcing his mouth to open. Quickly, you plug his maw with his own shaft, holding his head down, forcing him to coat his meat with his own saliva.  ");
+			//{If Corruption <30}
+			if (player.cor < 33)
+				outputText("In a brief moment of pity you reach down, stroking Akbal's strained balls as he suckles, feeling them quiver as he noisily slurps and drools.");
+			else
+				outputText("You smirk, grabbing his full sack almost roughly, shaking them as he stares at you with his emerald eyes, although with rage or lust you can't quite tell.");
+			outputText("\n\n");
+
+			outputText("Finally, you judge that he's done enough, allowing him to lift his head back up with a splutter, although considering the flowing pre around his tip and over his lips, the experience was hardly a painful one. He glares at you with his burning green eyes as you ");
+			//({if Player is naga}
+			if (player.isNaga())
+				outputText("rear up, supporting your weight on your own tail as your hands explore down below, finding your puffed up slit and slowly parting them with a pair of fingers, allowing your scent and dampness to coat the jaguar's snout.");
+			else if (player.isGoo())
+				outputText("reach out, your liquid-like body coating his legs and holding them open, your hands reaching down to play with your damp, open fuck hole, chuckling as he tries to feign disinterest despite the obvious throbbing of his sack.");
+			else
+				outputText(" begin to stand over him, spreading your legs to reveal your damp, open pussy, his expression turning comically from rage to confusion to one of sheer lust, the feline licking his lips despite his own flavor on them.");
+			outputText("\n\n");
+
+			outputText("Judging by the shudder of longing that runs through his body, it's clear that he's more turned on by your actions than he would have liked. Using your lower body to pin his legs down, you grab his arms as you sink down, moaning more for his benefit as you brush the tip of his slick member against your entrance.");
+			dynStats("lus", 50);
+			doNext(girlsRapeAkbalPart2_Loose);
+		}
+
+		private function girlsRapeAkbalPart2_Taur():void {
+			clearOutput();
+			outputText(images.showImage("akbal-deepwoods-female-taur-bindakbal"));
+			outputText("You moan deeply as the thick shaft spreads your lips wide, throbbing against your clit as the barbs shudder against your inner walls, pushing your rump firmly against his lower abdomen as you squirm, leaking over his waist");
+			if (player.hasCock())
+				outputText(", " + sMultiCockDesc() + " swinging back and forth, occasionally bumping into his bound legs");
+			outputText(". The demon groans, clenching his eyes shut as he refuses to like the treatment you're forcing on him, but his body betrays him as a liar as his felinehood thickens and lengthens, more than eager to stuff your box full. It's with no small shiver of delight when you drink in his moans of longing as you pull back to the very tip of his cock.\n\n");
+
+			//({If Corruption > 30}
+			if (player.cor > 33)
+				outputText("If you weren't so eager on using him to get off, you might have considered teasing him like that then leaving him bound to the tree.  ");
+			outputText("Quickly, you settle into a rhythm of rocking back and forth, the tree creaking as you throw your weight against it with every plunge down, the cat behind you reduced to a mewling, begging kitten, trying in vain to thrust into your sopping cunt.\n\n");
+
+			outputText("You continue like this for the better part of an hour, his barbs raking your insides and sending constant shivers through your body, but you just can't seem to get off on your bounces alone. Without really thinking it through, you release the vines holding Akbal's arms up to grope your own " + chestDesc() + ", fondling yourself roughly.\n\n");
+
+			outputText("Thankfully, Akbal is just as desperate to get off as you as he makes use of his new found freedom, one hand clutching the base of your tail, the other grabbing your flank with a clawed paw. Immediately he snarls, shoving his feline dong deep into you, a much better sensation then when you were merely rocking on him, your mare cunt squirting and clenching around him, trying to milk his seed");
+			if (player.hasCock())
+				outputText(", while your cock slaps at your stomach, pre flying from the tip to coat your lower body and the earth below");
+			outputText(". He buries himself deep over and over, his fat, swollen balls slapping against you, feeling oddly natural");
+			if (player.balls > 0) {
+				outputText(", your own swaying back to meet him");
+				//({If >=Grapefruit}
+				if (player.ballSize >= 12)
+					outputText(" dwarfing him despite his pent-up lusts");
+			}
+			outputText(", coaxing moans and groans of sheer pleasure to mingle with his snarls and purrs of enjoyment.\n\n");
+
+			outputText("In the end the jaguar finishes first, roaring his pleasure to the trees as he squirts his kitten-cream into your cunt, filling you up. If you were in any state to guess, you could probably imagine the cat filling up your womb as well judging by the swelling of your lower body, causing a flash of concern, wondering if the feline could possibly impregnate your womb. He's not finished however, as he continues to thrust through his release, pulling you higher and higher into orgasmic bliss as you finally release in tandem with his fifth orgasm. Your " + vaginaDescript() + " clenches tightly over him, coating his waist in fem juices as you milk him");
+			if (player.hasCock())
+				outputText(" as " + sMultiCockDesc() + " twitch and let loose, spraying the ground with your seed");
+			outputText(".\n\n");
+
+			outputText("Your body trembles as the demon sags down onto your lower back, clutching your equine hips lightly, as you want nothing more but to simply sag down with him, his weight oddly comfortable on your back. Shaking your head to clear it, you begin to turn round, careful not to dislodge Akbal from his obviously comfortable position as you feel him slowly start to shift back into his quadruped form, his dripping shaft slipping out of your pussy with an obscene slurping noise. Lowering your tail, you let the demon slip off, fumbling with the vines around his feet, releasing him as he sprawls on the ground in pure contentment. As you straighten up and start to head back to camp, you realize you feel the same way; perfectly content. Maybe it wouldn't be a bad idea to look out for the God in the future...");
+			//Imp pregnancy
+			//Preggers chance!
+			if (!player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
+			player.cuntChange(monster.cockArea(0), true, true, false);
+			player.sexReward("cum", "Vaginal");
 			dynStats("cor", 1);
 			cleanupAfterCombat();
 		}
 
-		private function girlsRapeAkbal():void
-		{
-			flags[kFLAGS.AKBAL_BITCH_Q]++;
+		private function girlsRapeAkbalPart2_Tight():void {
 			clearOutput();
-			outputText("You smirk to yourself quietly as the so called \"God of Terrestrial Fire\" lays in a twitching heap on the ground, his flesh squirming as he shifts into his more humanoid form. Removing your [armor], your hand lowers to your feminine slit, pondering how to make use of him.\n\n");
-			//{If Centaur}
-			outputText(images.showImage("akbal-deepwoods-female-bindakbal"));
-			if (player.isTaur())
-			{
-				outputText("Already you can see the trouble of trying to accommodate someone with your body type, but as they said in your village, \"<i>where there's a will, there's a way</i>\". Grabbing some of the vines from the nearby trees, you approach the nearly comatose Akbal and sling him over your back, grinning as you work through the details in your mind.\n\n");
-
-				outputText("Before the feline demon can recover and protest, you bind his arms to the end of the longest vines, throwing them over some of the stronger branches to make a makeshift pulley system. Hauling him up against the bark of the tree, he stirs slightly, but is still unable to work up the strength to fight back. Making the most of the time you figure you have left before he fully awakens, you bind his feet near the base of the tree, effectively turning him into a mounted toy for you to impale your " + vaginaDescript() + " upon.\n\n");
-
-				outputText("With his arms and legs bound, you take the time to examine your prize, reaching forward to stroke his full, baseball sized sack and swinging barbed shaft. It looks that despite the fact that you beat him into submission, the demon isn't totally opposed to the idea as he stirs to life in your hand, throbbing slightly. The jaguar starts to open his emerald eyes and glares at you, but nonetheless tries to push his hips forward, giving a snarl of annoyance when he can't work get proper leverage on the tree thanks to your binding.\n\n");
-
-				outputText("Keeping the vines holding his arms up in hand, you slowly turn around and lift your tail, allowing your sopping mare cunt to wink at Akbal");
-				if (player.hasCock())
-					outputText(" " + sMultiCockDesc() + " hanging beneath, twitching in anticipation");
-				outputText(". With a smirk at the helpless Gods expense, you take a step back, lining up before pushing yourself against him roughly, shoving his barbed feline shaft deeply into you.");
-			}
-			//{If Pussy is <loose}
-			else if (player.vaginalCapacity() < monster.cockArea(0))
-			{
-				outputText("Rolling him over onto his back with your foot, you tsk in annoyance, knowing that you won't be able to fit his large kitty-cock between your legs without some considerable pain, and you don't really trust the demon to let his mouth, with all those oh-so-sharp teeth, near your most sensitive areas. Thankfully, another option is available, currently twitching around your feet.\n\n");
-
-				outputText("Reaching down, you grab his flicking tail, ignoring his feline yowl of discomfort, stroking the spotted, silky smooth fur with a few fingers, the sensation creating shivers of lust up your spine. Already images bloom in your mind, creating all kinds of acts you could use this appendage for and plucking the most prominent one from your mind, you grab the demon cat by the scruff of his neck, ");
-				//({If strength >60}
-				if (player.str > 60)
-					outputText("hauling him towards a tree like a newborn kitten");
-				else
-					outputText("dragging him towards the nearest tree");
-				outputText(" and forcing him to lean back against it.\n\n");
-
-				outputText("Gripping his tail once more, you grab him by the fur of his head and yank him down to meet the tip, pressing insistently against his lips. Even in his weakened state Akbal refuses until you happen to glance down between his legs. It seems like the demon is more turned on by you taking charge than he would like to admit.  ");
-				//({if Naga}
-				if (player.isNaga())
-					outputText("You curl the tip of your tail around his length, catching the barbs lightly on your scales and squeezing, coaxing a low yowl of pleasure which you hurriedly make use of, ");
-				//{If Goo}
-				else if (player.isGoo())
-					outputText("You focus, extending a small part of your liquid-like body, enveloping his feline meat in yourself, careful to avoid the tip. The sensation of damp warmth around his feline member is too much, making him open his mouth in a silent moan which you hastily use, ");
-				else
-					outputText("Lifting up your [leg], you firmly place the sole of your foot against his barbed flesh, pressing it against his stomach, forcing the jaguar to let out a low moan which you quickly take advantage of, ");
-
-				outputText("stuffing his own tail into his maw.  As he tries to push his tail back out, you remove your [foot] pointedly, staring down at the demon. Lifting his hips back up weakly towards you, he meekly begins to suckle on his own appendage, closing his vibrant emerald eyes as you return your attention to his shaft.\n\n");
-			}
-			//{If Pussy >= Loose}
-			else
-			{
-				outputText("You grin as you flip him over onto his back, staring down at his breeding tool between his legs, firmly erect as it rests on his rather full set of balls. Quite clearly, this \"<i>God</i>\" hasn't had much action for quite some time, hence his aggressive nature towards you. You finger yourself slightly as you examine his feline shaft, coated with layers of barbs that look as though they would be quite painful. Leaning down, you run your fingers over them, smirking as they bend slightly. They may not be enough to harm you, but sex would definitely be unpleasant... unless you happened to have a source of suitable lube nearby.\n\n");
-				outputText("Remembering the cats back home");
-				//({If player has the flexibility Perk}
-				if (player.hasPerk(PerkLib.Flexibility))
-					outputText(" and your own experience with such matters");
-				outputText(", you figure you have a pretty good idea where a reliable source of lube could be. You grin as you grab the demon cat by the scruff of his neck, ");
-				//({If strength >60}
-				if (player.str > 60)
-					outputText("hauling him towards a tree like a newborn kitten");
-				else
-					outputText("dragging him towards the nearest tree");
-				outputText(" and forcing him to lean back against it.\n\n");
-
-				outputText("In his dazed state, Akbal offers little resistance when you position him against the tree. That changes however, when you grab the hair of his head and push him down towards his own straining cock. Angry whispers flit at the edge of your mind, easily brushed aside as you reach down and squeeze the demon's cheeks, forcing his mouth to open. Quickly, you plug his maw with his own shaft, holding his head down, forcing him to coat his meat with his own saliva.  ");
-				//{If Corruption <30}
-				if (player.cor < 33)
-					outputText("In a brief moment of pity you reach down, stroking Akbal's strained balls as he suckles, feeling them quiver as he noisily slurps and drools.");
-				else
-					outputText("You smirk, grabbing his full sack almost roughly, shaking them as he stares at you with his emerald eyes, although with rage or lust you can't quite tell.");
-				outputText("\n\n");
-
-				outputText("Finally, you judge that he's done enough, allowing him to lift his head back up with a splutter, although considering the flowing pre around his tip and over his lips, the experience was hardly a painful one. He glares at you with his burning green eyes as you ");
-				//({if Player is naga}
-				if (player.isNaga())
-					outputText("rear up, supporting your weight on your own tail as your hands explore down below, finding your puffed up slit and slowly parting them with a pair of fingers, allowing your scent and dampness to coat the jaguar's snout.");
-				else if (player.isGoo())
-					outputText("reach out, your liquid-like body coating his legs and holding them open, your hands reaching down to play with your damp, open fuck hole, chuckling as he tries to feign disinterest despite the obvious throbbing of his sack.");
-				else
-					outputText(" begin to stand over him, spreading your legs to reveal your damp, open pussy, his expression turning comically from rage to confusion to one of sheer lust, the feline licking his lips despite his own flavor on them.");
-				outputText("\n\n");
-
-				outputText("Judging by the shudder of longing that runs through his body, it's clear that he's more turned on by your actions than he would have liked. Using your lower body to pin his legs down, you grab his arms as you sink down, moaning more for his benefit as you brush the tip of his slick member against your entrance.");
-			}
-			dynStats("lus", 50);
-			//-Page Turn-
-			doNext(girlsRapeAkbalPart2);
-		}
-
-		private function girlsRapeAkbalPart2():void
-		{
-			clearOutput();
-			EngineCore.hideUpDown();
-			//Centaur
 			outputText(images.showImage("akbal-deepwoods-female-taur-bindakbal"));
-			if (player.isTaur())
-			{
-				outputText("You moan deeply as the thick shaft spreads your lips wide, throbbing against your clit as the barbs shudder against your inner walls, pushing your rump firmly against his lower abdomen as you squirm, leaking over his waist");
-				if (player.hasCock())
-					outputText(", " + sMultiCockDesc() + " swinging back and forth, occasionally bumping into his bound legs");
-				outputText(". The demon groans, clenching his eyes shut as he refuses to like the treatment you're forcing on him, but his body betrays him as a liar as his felinehood thickens and lengthens, more than eager to stuff your box full. It's with no small shiver of delight when you drink in his moans of longing as you pull back to the very tip of his cock.\n\n");
-
-				//({If Corruption > 30}
-				if (player.cor > 33)
-					outputText("If you weren't so eager on using him to get off, you might have considered teasing him like that then leaving him bound to the tree.  ");
-				outputText("Quickly, you settle into a rhythm of rocking back and forth, the tree creaking as you throw your weight against it with every plunge down, the cat behind you reduced to a mewling, begging kitten, trying in vain to thrust into your sopping cunt.\n\n");
-
-				outputText("You continue like this for the better part of an hour, his barbs raking your insides and sending constant shivers through your body, but you just can't seem to get off on your bounces alone. Without really thinking it through, you release the vines holding Akbal's arms up to grope your own " + chestDesc() + ", fondling yourself roughly.\n\n");
-
-				outputText("Thankfully, Akbal is just as desperate to get off as you as he makes use of his new found freedom, one hand clutching the base of your tail, the other grabbing your flank with a clawed paw. Immediately he snarls, shoving his feline dong deep into you, a much better sensation then when you were merely rocking on him, your mare cunt squirting and clenching around him, trying to milk his seed");
-				if (player.hasCock())
-					outputText(", while your cock slaps at your stomach, pre flying from the tip to coat your lower body and the earth below");
-				outputText(". He buries himself deep over and over, his fat, swollen balls slapping against you, feeling oddly natural");
-				if (player.balls > 0)
-				{
-					outputText(", your own swaying back to meet him");
-					//({If >=Grapefruit}
-					if (player.ballSize >= 12)
-						outputText(" dwarfing him despite his pent up lusts");
-				}
-				outputText(", coaxing moans and groans of sheer pleasure to mingle with his snarls and purrs of enjoyment.\n\n");
-
-				outputText("In the end the jaguar finishes first, roaring his pleasure to the trees as he squirts his kitten-cream into your cunt, filling you up. If you were in any state to guess, you could probably imagine the cat filling up your womb as well judging by the swelling of your lower body, causing a flash of concern, wondering if the feline could possibly impregnate your womb. He's not finished however, as he continues to thrust through his release, pulling you higher and higher into orgasmic bliss as you finally release in tandem with his fifth orgasm. Your " + vaginaDescript() + " clenches tightly over him, coating his waist in fem juices as you milk him");
-				if (player.hasCock())
-					outputText(" as " + sMultiCockDesc() + " twitch and let loose, spraying the ground with your seed");
-				outputText(".\n\n");
-
-				outputText("Your body trembles as the demon sags down onto your lower back, clutching your equine hips lightly, as you want nothing more but to simply sag down with him, his weight oddly comfortable on your back. Shaking your head to clear it, you begin to turn round, careful not to dislodge Akbal from his obviously comfortable position as you feel him slowly start to shift back into his quadruped form, his dripping shaft slipping out of your pussy with an obscene slurping noise. Lowering your tail, you let the demon slip off, fumbling with the vines around his feet, releasing him as he sprawls on the ground in pure contentment. As you straighten up and start to head back to camp, you realize you feel the same way; perfectly content. Maybe it wouldn't be a bad idea to look out for the God in the future...");
-				//Imp pregnancy
-				//Preggers chance!
-				if (!player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
-				player.cuntChange(monster.cockArea(0), true, true, false);
-				player.sexReward("cum", "Dick");
-				dynStats("cor", 1);
-			}
-			//TOIGHT
-			else if (player.vaginalCapacity() < monster.cockArea(0))
-			{
-				//-Page Turn-
-				outputText("Judging the silky fur to be slick enough, you yank out the tail from his mouth, pulling it towards your " + vaginaDescript() + " lips, teasing your folds with the tip before guiding him in. Taking the hint, the feline squirms his tail, pushing into you as he lifts his hips up once more, purring lightly as he presses himself against your [foot].  His cock is already leaking pre from the tip.  You gasp loudly as his fur bristles inside you, his saliva making your womanhood quiver in need as you feel him slip deeper, coiling and twisting. Making sure not to neglect the feline, you");
-				//({If Naga}
-				if (player.isNaga())
-					outputText(" squeeze his meat tighter, moving your coils up and down his feline prick while using the very tip of your tail to tease and poke his urethra, coating it in his pre");
-				//({If Goo}
-				else if (player.isGoo())
-					outputText(" squirm and writhe over the base of his feline shaft, vibrating your liquid-like appendage like a living sex toy, causing his balls to jiggle slightly");
-				//({If Bipedal}
-				else
-					outputText(" press his shaft firmer against his stomach, slowly slipping the sole of your foot up and down his length, coaxing out small yowls and purrs of pleasure");
-				outputText(" as silent payment for the pleasure he's flooding your pussy with.\n\n");
-
-				outputText("Time seems to stretch as you stand there, pinning the god, once so proud and mighty, now just a mewling kitten devoted to your pleasure");
-				//({If Herm}
-				if (player.hasCock())
-					outputText(" while you stroke " + oMultiCockDesc() + " in time with his thrusts");
-				outputText(". His flexible tail pokes and strokes your deepest recesses as you keep him permanently on the edge with your teasing treatment while his sharp claws dig furrows into the earth as he strains up against you, too caught up in his pleasure to mentally voice his desires. Instead, he opens his maw to signal his lust as a savage beast would, full of yowls, snarls and purrs, creating an oddly pleasing cacophony to your ears, making you feel like the " + player.mf("Ruler of Beasts", "Queen of Beasts") + ", adding your own savage calls to his.\n\n");
-
-				outputText("The squirming of his tail becomes too much however, as a familiar pressure builds up down below. Increasing the pace upon which you please his shaft, you lower yourself, trying to push more of that skilled tail into you, ");
-				//({If Herm}
-				if (player.gender == 3)
-					outputText("stroking " + oMultiCockDesc() + " roughly, ");
-				outputText("moaning loudly as your pussy lips begin to clench and tighten, slick juices trickling down his fur. Sensing your closeness, Akbal redoubles his efforts, his writhing tail bristling, dragging his fur along your insides. Finally it becomes too much as you release, your thick fem juices pouring out of your stuffed pussy, falling down onto his straining shaft");
-				if (player.hasCock())
-					outputText(" as " + sMultiCockDesc() + " offers up its bounty, spasming and adding to the mess");
-				outputText(". The added heat and wetness of your orgasm sets him over the edge as he gives a roar loud enough to shake the trees, his thick, barbed shaft squirting hard, arcing his back as his seed splats onto the leaves of the tree above, falling down as a perverse rain over the pair of you.\n\n");
-
-				outputText("Your " + chestDesc() + " chest heaves as you struggle to gulp air, [legs] quivering from the sheer power of the orgasm the cat's tail gave you.  ");
-				//({if cum volume > normal}
-				if (player.cumQ() > 500)
-					outputText("His entire waist is coated in your juices, the once proud cat sitting in a pool of your leavings, with a contented grin on his face, like the cat that caught the canary");
-				//({If cum volume low/normal}
-				else
-					outputText("He sits, dazed as your cum covers his groin, his meat still shiny from the torrent you dropped down upon it. Nevertheless, his face is twisted into a purr");
-				outputText(" as he sags against the tree trunk, overwhelmed by the pleasure. With a satisfied grin of your own, you pick up your [armor] and head out. Perhaps you should look out for the \"<i>God of Terrestrial fire</i>\" again sometime...");
-				//{No Penetration or fluids exchanged = No corruption increase? Poss. Sensitivity increase/decrease due to fur and/or saliva}
-				player.sexReward("Default","Vaginal",true,false);
-			}
-			//= = = =
-			//Loose
+			//-Page Turn-
+			outputText("Judging the silky fur to be slick enough, you yank out the tail from his mouth, pulling it towards your " + vaginaDescript() + " lips, teasing your folds with the tip before guiding him in. Taking the hint, the feline squirms his tail, pushing into you as he lifts his hips up once more, purring lightly as he presses himself against your [foot].  His cock is already leaking pre from the tip.  You gasp loudly as his fur bristles inside you, his saliva making your womanhood quiver in need as you feel him slip deeper, coiling and twisting. Making sure not to neglect the feline, you");
+			//({If Naga}
+			if (player.isNaga())
+				outputText(" squeeze his meat tighter, moving your coils up and down his feline prick while using the very tip of your tail to tease and poke his urethra, coating it in his pre");
+			//({If Goo}
+			else if (player.isGoo())
+				outputText(" squirm and writhe over the base of his feline shaft, vibrating your liquid-like appendage like a living sex toy, causing his balls to jiggle slightly");
+			//({If Bipedal}
 			else
-			{
-				outputText("You groan loudly as Akbal's impressive shaft stretches your pussy wide, instantly thankful that you had the idea to lube him up beforehand. Your less-than-willing partner adds his own groan to yours, the twitching of his meat signalling that he's not quite to opposed to the idea as he makes out. Maybe he's got a thing about dominance, from either angle. Nevertheless, you continue to push down until your hips reach his with a light bump. The sensation of his immense cock filling you up causes you to shudder, before leaning into the demon, pressing your " + chestDesc() + " against his, revealing in his silky fur stroking multiple parts of your body all at once. The yowling male takes off, ducking his head to lick and nip at your " + nippleDescript(0) + "s");
-				//({If Lactating}
-				if (player.biggestLactation() >= 1)
-					outputText(", adding a purr of pleasant surprise as he locks his lips around one nipple, drawing out mouthfuls of your sweet milk before gulping it down.  The sheer taboo of feeding a demon your milk sends shivers down your spine");
-				outputText(".\n\n");
+				outputText(" press his shaft firmer against his stomach, slowly slipping the sole of your foot up and down his length, coaxing out small yowls and purrs of pleasure");
+			outputText(" as silent payment for the pleasure he's flooding your pussy with.\n\n");
 
-				outputText("As you lift yourself off, your head begins to swim as his previously unnoticed barbs rake along your inner walls, tugging, catching and massaging from the inside as they start to vibrate, causing you to ");
-				//({if Naga}
-				if (player.isNaga())
-					outputText("wrap your coils around him and the tree, adding leverage to your plunges down");
-				//({If Goo}
-				else if (player.isGoo())
-					outputText("encase yourself around his hips and groin, your entire lower body writhing and squirming around his shaft");
-				//({If Bipedal}
-				else
-					outputText("lock your legs around his torso, bouncing upon him with greater force");
-				outputText(".  As your mouth hangs open, the demon lunges forward, pressing his own snout against your [face]. You can still taste the traces of his own pre on his lips and tongue, furthering your lust as you use his groin roughly, impaling yourself hard enough to leave bruises on the pair of you, while he uses his tail to ");
-				//({if herm}
-				if (player.cockTotal() == 1)
-					outputText("wrap around your own straining shaft, the fur enhancing the effects of his pumps");
-				//({If more than 1 cock}
-				else if (player.cockTotal() > 1)
-					outputText("wrap around each of your throbbing malehoods with difficulty, teasing them with his bristled fur");
-				//({If female}
-				else
-					outputText("stroke and tickle your ass and lower back");
-				outputText(".\n\n");
+			outputText("Time seems to stretch as you stand there, pinning the god, once so proud and mighty, now just a mewling kitten devoted to your pleasure");
+			//({If Herm}
+			if (player.hasCock())
+				outputText(" while you stroke " + oMultiCockDesc() + " in time with his thrusts");
+			outputText(". His flexible tail pokes and strokes your deepest recesses as you keep him permanently on the edge with your teasing treatment while his sharp claws dig furrows into the earth as he strains up against you, too caught up in his pleasure to mentally voice his desires. Instead, he opens his maw to signal his lust as a savage beast would, full of yowls, snarls and purrs, creating an oddly pleasing cacophony to your ears, making you feel like the " + player.mf("Ruler of Beasts", "Queen of Beasts") + ", adding your own savage calls to his.\n\n");
 
-				outputText("You're not sure how long you sit there, bouncing roughly on the feline demon's cock, his eyes clenched tightly shut as he revels in the feeling of your warm damp pussy and your [butt] grinding against his swollen sack. Eventually, his combined efforts of mouth, shaft and tail force you over the edge, your hungry pussy lips clenching tightly over him, rhythmically squeezing as you attempt to milk his shaft");
-				//({if Herm}
-				if (player.hasCock())
-					outputText(" as " + sMultiCockDesc() + "  twitches and strains, ready to blow");
-				outputText(", and he certainly doesn't disappoint. With a roar loud enough to shake the trees, he erupts violently within your passage, his hot, steaming, fertile seed pouring into your depths");
-				//({if Herm}
-				if (player.cockTotal() == 1)
-					outputText(", setting your own malehood off in sympathy, squirting thick cream over his chest");
-				else if (player.cockTotal() > 1)
-					outputText(" setting each of your malenesses surging, splattering the feline with your seed");
-				outputText(", his face twisted into a snarl of pleasure and satisfaction.\n\n");
+			outputText("The squirming of his tail becomes too much however, as a familiar pressure builds up down below. Increasing the pace upon which you please his shaft, you lower yourself, trying to push more of that skilled tail into you, ");
+			//({If Herm}
+			if (player.gender == 3)
+				outputText("stroking " + oMultiCockDesc() + " roughly, ");
+			outputText("moaning loudly as your pussy lips begin to clench and tighten, slick juices trickling down his fur. Sensing your closeness, Akbal redoubles his efforts, his writhing tail bristling, dragging his fur along your insides. Finally, it becomes too much as you release, your thick fem juices pouring out of your stuffed pussy, falling down onto his straining shaft");
+			if (player.hasCock())
+				outputText(" as " + sMultiCockDesc() + " offers up its bounty, spasming and adding to the mess");
+			outputText(". The added heat and wetness of your orgasm sets him over the edge as he gives a roar loud enough to shake the trees, his thick, barbed shaft squirting hard, arcing his back as his seed splats onto the leaves of the tree above, falling down as a perverse rain over the pair of you.\n\n");
 
-				outputText("You slowly come down from your orgasmic high, struggling to remove yourself from the demon's lap and heading unsteadily towards your [armor] as fresh feline seed pours down your body, wincing at the slight bruising to your womanhood. Rubbing a hand over your stomach, you start to wonder if perhaps it was a touch risky to allow a demon to shoot his seed into your womb. However, despite the mild throbbing, you feel refreshed and oddly strengthened by Akbal's potent seed, glancing over your shoulder to see the once proud god reveling in his own release. Perhaps it wouldn't be a bad idea to seek him out some other time...");
-				player.sexReward("cum", "Vaginal");
-				dynStats("cor", 1);
-				//Imp pregnancy
-				//Preggers chance!
-				if (!player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
-			}
+			outputText("Your " + chestDesc() + " chest heaves as you struggle to gulp air, [legs] quivering from the sheer power of the orgasm the cat's tail gave you.  ");
+			//({if cum volume > normal}
+			if (player.cumQ() > 500)
+				outputText("His entire waist is coated in your juices, the once proud cat sitting in a pool of your leavings, with a contented grin on his face, like the cat that caught the canary");
+			//({If cum volume low/normal}
+			else
+				outputText("He sits, dazed as your cum covers his groin, his meat still shiny from the torrent you dropped down upon it. Nevertheless, his face is twisted into a purr");
+			outputText(" as he sags against the tree trunk, overwhelmed by the pleasure. With a satisfied grin of your own, you pick up your [armor] and head out. Perhaps you should look out for the \"<i>God of Terrestrial fire</i>\" again sometime...");
+			//{No Penetration or fluids exchanged = No corruption increase? Poss. Sensitivity increase/decrease due to fur and/or saliva}
+			player.sexReward("Default", "Vaginal", true, false);
 			cleanupAfterCombat();
 		}
 
-		private function loseToAckballllllz():void
-		{
-			//[Defeat via Lust]
-			if (!player.isTaur())
-			{
-				outputText(images.showImage("akbal-deepwoods-losslust-analed"));
-				outputText("You fall to your knees and begin to feverishly masturbate.  Akbal rises onto his two hind legs, his body shifting into a more humanoid form as he stands.  His long cock swings ominously between his legs as he walks towards you.  The first thing he does is pull his massive 15-inch cock to your lips, slapping the shaft against your chin.\n\n");
-				outputText("Like a whore in heat, you open your mouth and lewdly lick the jaguar demon's cock head, feeling odd barbs rub against your tongue.  Your mouth opens wide, but can't even get past the head before the sheer girth of Akbal's massive sex organ halts its advance.  Akbal is content to let you orally fumble with the head for only a few moments before he pushes down onto your back. His claws tickle your thighs as he forces your [legs] up over your head, bringing your " + assholeDescript() + " into plain view.\n\n");
-				outputText("\"<i>Defiance repaid,</i>\" is all you hear from the chorus of voices in your head as Akbal displays his massive length to you.  Your eyes widen in horror, counting a dozen wicked-looking barbs on the head of his overtly thick and over-sized cock.\n\n");
+		private function girlsRapeAkbalPart2_Loose():void {
+			clearOutput();
+			outputText(images.showImage("akbal-deepwoods-female-taur-bindakbal"));
+			outputText("You groan loudly as Akbal's impressive shaft stretches your pussy wide, instantly thankful that you had the idea to lube him up beforehand. Your less-than-willing partner adds his own groan to yours, the twitching of his meat signalling that he's not quite to opposed to the idea as he makes out. Maybe he's got a thing about dominance, from either angle. Nevertheless, you continue to push down until your hips reach his with a light bump. The sensation of his immense cock filling you up causes you to shudder, before leaning into the demon, pressing your " + chestDesc() + " against his, revealing in his silky fur stroking multiple parts of your body all at once. The yowling male takes off, ducking his head to lick and nip at your " + nippleDescript(0) + "s");
+			//({If Lactating}
+			if (player.biggestLactation() >= 1)
+				outputText(", adding a purr of pleasant surprise as he locks his lips around one nipple, drawing out mouthfuls of your sweet milk before gulping it down.  The sheer taboo of feeding a demon your milk sends shivers down your spine");
+			outputText(".\n\n");
+
+			outputText("As you lift yourself off, your head begins to swim as his previously unnoticed barbs rake along your inner walls, tugging, catching and massaging from the inside as they start to vibrate, causing you to ");
+			//({if Naga}
+			if (player.isNaga())
+				outputText("wrap your coils around him and the tree, adding leverage to your plunges down");
+			//({If Goo}
+			else if (player.isGoo())
+				outputText("encase yourself around his hips and groin, your entire lower body writhing and squirming around his shaft");
+			//({If Bipedal}
+			else
+				outputText("lock your legs around his torso, bouncing upon him with greater force");
+			outputText(".  As your mouth hangs open, the demon lunges forward, pressing his own snout against your [face]. You can still taste the traces of his own pre on his lips and tongue, furthering your lust as you use his groin roughly, impaling yourself hard enough to leave bruises on the pair of you, while he uses his tail to ");
+			//({if herm}
+			if (player.cockTotal() == 1)
+				outputText("wrap around your own straining shaft, the fur enhancing the effects of his pumps");
+			//({If more than 1 cock}
+			else if (player.cockTotal() > 1)
+				outputText("wrap around each of your throbbing malehoods with difficulty, teasing them with his bristled fur");
+			//({If female}
+			else
+				outputText("stroke and tickle your ass and lower back");
+			outputText(".\n\n");
+
+			outputText("You're not sure how long you sit there, bouncing roughly on the feline demon's cock, his eyes clenched tightly shut as he revels in the feeling of your warm damp pussy and your [butt] grinds against his swollen sack. Eventually, his combined efforts of mouth, shaft and tail force you over the edge, your hungry pussy lips clenching tightly over him, rhythmically squeezing as you attempt to milk his shaft");
+			//({if Herm}
+			if (player.hasCock())
+				outputText(" as " + sMultiCockDesc() + "  twitches and strains, ready to blow");
+			outputText(", and he certainly doesn't disappoint. With a roar loud enough to shake the trees, he erupts violently within your passage, his hot, steaming, fertile seed pouring into your depths");
+			//({if Herm}
+			if (player.cockTotal() == 1)
+				outputText(", setting your own malehood off in sympathy, squirting thick cream over his chest");
+			else if (player.cockTotal() > 1)
+				outputText(" setting each of your malenesses surging, splattering the feline with your seed");
+			outputText(", his face twisted into a snarl of pleasure and satisfaction.\n\n");
+
+			outputText("You slowly come down from your orgasmic high, struggling to remove yourself from the demon's lap and heading unsteadily towards your [armor] as fresh feline seed pours down your body, wincing at the slight bruising to your womanhood. Rubbing a hand over your stomach, you start to wonder if perhaps it was a touch risky to allow a demon to shoot his seed into your womb. However, despite the mild throbbing, you feel refreshed and oddly strengthened by Akbal's potent seed, glancing over your shoulder to see the once proud god reveling in his own release. Perhaps it wouldn't be a bad idea to seek him out some other time...");
+			player.sexReward("cum", "Vaginal");
+			dynStats("cor", 1);
+			//Imp pregnancy
+			//Preggers chance!
+			if (!player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
+			player.sexReward("cum", "Vaginal");
+			cleanupAfterCombat();
+		}
+
+		private function akbalRapesTaurs():void {
+			outputText(images.showImage("akbal-deepwoods-losslust-taur-analed"));
+			outputText("You stumble like a drunken pony as your lust goes into the red zone, and you know in the pit of your stomach that you are at this wicked demon's mercy.\n\n");
+
+			outputText("Akbal rises onto his two hind legs, his body becoming more humanoid as he does. His long, semi-erect cock swings ominously his legs as he walks towards you.\n\n");
+
+			outputText("\"<i>Defiance repaid,</i>\" is all you hear from the chorus of voices in your head as Akbal displays his massive length to you. Your eyes widen in horror as you count a dozen wicked looking barbs on the head of his overtly thick, gargantuan cock.\n\n");
+
+			sceneHunter.print("Fork: anal looseness, tight/loose/gaping");
+			if (player.ass.analLooseness < AssClass.LOOSENESS_LOOSE) {
+				outputText("Akbal begins to push into you, the barbs on his massive head causing you to howl as your " + assholeDescript() + " is forcibly stretched. His jaguar claws grab your sides as he uses your body as leverage to force his demonic erection into you.\n\n");
+
+				outputText("When Akbal shoves forward the strain makes you feel as though you are going to pass out; the pain from his spiked sex organ is just enough to leave you conscious. He begins to withdraw, and you realize he's not even forcing half the length of that swollen sex organ into your " + assholeDescript() + ".\n\n");
+
+				outputText("After hours of Akbal's long cat dick being slowly forced into your " + assholeDescript() + " your body gives out, and you become too exhausted from the strain to even lift your arms. With a triumphant growl Akbal thrusts forward, his cock head spikes burying themselves into you but, without your resistance, they seem to vibrate inside you like twelve little beads massaging your innards. The sudden change makes you croon as you paw the ground with your hooves, suddenly desperate for more.");
 			}
-			//Centaurs R SPECIALZ
-			else if (player.isTaur())
-			{
-				outputText(images.showImage("akbal-deepwoods-losslust-taur-analed"));
-				outputText("You stumble like a drunken pony as your lust goes into the red zone and you know in the pit of your stomach that you are at this wicked demon's mercy.\n\n");
+			else if (player.ass.analLooseness < AssClass.LOOSENESS_GAPING) {
+				outputText("Akbal begins to push into you, the barbs on his massive cock head causing you to wince as you are forcibly stretched. Without warning, he forces the entirety of his massive length into you with a snarl. The initial incursion makes you grind your teeth as that spiked rod invades your " + assholeDescript() + ".  You widen your stance in an attempt to lessen the sudden slicing pressure created by the barbed cock head. The moment you do the barbs start to vibrate, beginning to feel more like humming sex beads than the wicked looking battering ram you know is inside you. You can't suppress the sudden sounds coming from your throat and exclaiming your ecstasy to your rapist.");
+			}
+			else {
+				outputText("Akbal begins to push into you, the barbs on his massive cock head causing you to wince. He bottoms out instantly, and you hear a pleased purr behind you. As he begins to pump his blood engorged sex organ in and out of your " + assholeDescript() + " with steadily mounting force you can't help but wonder why the barbs aren't causing you pain. You release a groan as those very barbs start to vibrate and begin feeling more like humming sex beads than punishing spikes.\n\n");
 
-				outputText("Akbal rises onto his two hind legs, his body becoming more humanoid as he does. His long, semi-erect cock swings ominously his legs as he walks towards you.\n\n");
+				outputText("Akbal snarls as he slams his hips into you, obviously happy that you're able to take his massive length. The demon appears to forget he's raping you and begins licking the back of your horse-like bottom half, sending shivers throughout your entire body as he roughly fucks you while painting your back with his saliva.");
+			}
+			player.buttChange(new Akbal().cockArea(0), true);
+			outputText("\n\n");
 
-				outputText("\"<i>Defiance repaid,</i>\" is all you hear from the chorus of voices in your head as Akbal displays his massive length to you. Your eyes widen in horror as you count a dozen wicked looking barbs on the head of his overtly thick, gargantuan cock.\n\n");
+			//(Ending)
+			outputText("The entire length of Akbal's embedded cock begins to hum inside you, causing you to cry out as he picks up the pace. His every thrust is a hammer-like thump against your hungry cheeks. Without warning his thrusts become sloppy, and you feel his giant tool swelling inside you, stretching you out even more.\n\n");
 
-				//(Small/Virgin Pucker)
-				if (player.ass.analLooseness < 3)
-				{
-					outputText("Akbal begins to push into you, the barbs on his massive head causing you to howl as your " + assholeDescript() + " is forcibly stretched. His jaguar claws grab your sides as he uses your body as leverage to force his demonic erection into you.\n\n");
+			outputText("Suddenly Akbal roars as he reaches his climax. You feel his giant cock hosing down your insides, filling you with his corrupted demon seed as he rides out his orgasm. His hips never stop. You feel your own orgasm rising to the surface only to suddenly fizzle out, and you realize the corrupted seed inside you is actually stopping you from reaching climax. Akbal, however, sprays his spunk into your " + assholeDescript() + " again and again and never slows for a moment. Soon your stomach is obscenely swollen, and you even taste cat jizz in your throat. Yet Akbal just keeps going, brutally fucking your helpless body and denying you release.\n\n");
 
-					outputText("When Akbal shoves forward the strain makes you feel as though you are going to pass out; the pain from his spiked sex organ is just enough to leave you conscious. He begins to withdraw and you realize he's not even forcing half the length of that swollen sex organ into your " + assholeDescript() + ".\n\n");
+			outputText("After hours of being his toy you pass out, never having reached your own orgasm.");
+			player.sexReward("cum", "Anal", false); //NEVER, blyat
+			dynStats("lust+", 10 + player.lib / 10, "cor+", 5 + rand(10));
+		}
 
-					outputText("After hours of Akbal's long cat dick being slowly forced into your " + assholeDescript() + " your body gives out and you become too exhausted from the strain to even lift your arms. With a triumphant growl Akbal thrusts forward, his cock head spikes burying themselves into you but, without your resistance, they seem to vibrate inside you like twelve little beads massaging your innards. The sudden change makes you croon as you paw the ground with your hooves, suddenly desperate for more.");
-				}
-				//(Medium Pucker)
-				else if (player.ass.analLooseness < 5)
-				{
-					outputText("Akbal begins to push into you, the barbs on his massive cock head causing you to wince as you are forcibly stretched. Without warning he forces the entirety of his massive length into you with a snarl. The initial incursion makes you grind your teeth as that spiked rod invades your " + assholeDescript() + ".  You widen your stance in an attempt to lessen the sudden slicing pressure created by the barbed cock head. The moment you do the barbs start to vibrate, beginning to feel more like humming sex beads than the wicked looking battering ram you know is inside you. You can't suppress the sudden sounds coming from your throat and exclaiming your ecstasy to your rapist.");
-				}
-				//(Gapping Pucker)
-				//[hp heals 50% after this if that's ok with
-				//you Fen]
-				else
-				{
-					outputText("Akbal begins to push into you, the barbs on his massive cock head causing you to wince. He bottoms out instantly and you hear a pleased purr behind you. As he begins to pump his blood engorged sex organ in and out of your " + assholeDescript() + " with steadily mounting force you can't help but wonder why the barbs aren't causing you pain. You release a groan as those very barbs start to vibrate and begin feeling more like humming sex beads than punishing spikes.\n\n");
-
-					outputText("Akbal snarls as he slams his hips into you, obviously happy that you're able to take his massive length. The demon appears to forget he's raping you and begins licking the back of your horse-like bottom half, sending shivers throughout your entire body as he roughly fucks you while painting your back with his saliva.");
-				}
-				player.buttChange(new Akbal().cockArea(0), true);
-				outputText("\n\n");
-
-				//(Ending)
-				outputText("The entire length of Akbal's embedded cock begins to hum inside you, causing you to cry out as he picks up the pace. His every thrust is a hammer-like thump against your hungry cheeks. Without warning his thrusts become sloppy and you feel his giant tool swelling inside you, stretching you out even more.\n\n");
-
-				outputText("Suddenly Akbal roars as he reaches his climax. You feel his giant cock hosing down your insides, filling you with his corrupted demon seed as he rides out his orgasm. His hips never stop. You feel your own orgasm rising to the surface only to suddenly fizzle out and you realize the corrupted seed inside you is actually stopping you from reaching climax. Akbal, however, sprays his spunk into your " + assholeDescript() + " again and again and never slows for a moment. Soon your stomach is obscenely swollen and you even taste cat jizz in your throat. Yet Akbal just keeps going, brutally fucking your helpless body and denying you release.\n\n");
-
-				outputText("After hours of being his toy you pass out, never having reached your own orgasm.");
-				player.sexReward("cum", "Anal");
-				dynStats("lust+",10 + player.lib / 10,"cor+",5 + rand(10));
+		private function loseToAckballllllz():void {
+			if (player.isTaur) {
+				akbalRapesTaurs();
 				return;
-				//Centaur over
 			}
-			if (player.ass.analLooseness < 3) //[Small/virgin pucker]
-			{
+			outputText(images.showImage("akbal-deepwoods-losslust-analed"));
+			sceneHunter.print("Check failed: taur lower body");
+			outputText("You fall to your knees and begin to feverishly masturbate.  Akbal rises onto his two hind legs, his body shifting into a more humanoid form as he stands.  His long cock swings ominously between his legs as he walks towards you.  The first thing he does is pull his massive 15-inch cock to your lips, slapping the shaft against your chin.\n\n");
+			outputText("Like a whore in heat, you open your mouth and lewdly lick the jaguar demon's cock head, feeling odd barbs rub against your tongue.  Your mouth opens wide, but can't even get past the head before the sheer girth of Akbal's massive sex organ halts its advance.  Akbal is content to let you orally fumble with the head for only a few moments before he pushes down onto your back. His claws tickle your thighs as he forces your [legs] up over your head, bringing your " + assholeDescript() + " into plain view.\n\n");
+			outputText("\"<i>Defiance repaid,</i>\" is all you hear from the chorus of voices in your head as Akbal displays his massive length to you.  Your eyes widen in horror, counting a dozen wicked-looking barbs on the head of his overtly thick and over-sized cock.\n\n");
+
+			sceneHunter.print("Fork: anal looseness, tight/loose/gaping");
+			if (player.ass.analLooseness < AssClass.LOOSENESS_LOOSE) {
 				outputText("Akbal begins to push into you, the barbs on his massive cockhead causing you to howl as your " + assholeDescript() + " is forcibly stretched.  His jaguar claws grab your shoulders, and he uses your body as leverage to force his demonic erection into you.\n\n");
 				outputText("The strain from Akbal's shoving makes you feel like you're going to pass out, yet the pain from his spiked sex organ keeps you conscious. After a while, you realize he's not even fucking you with his entire length; his swollen member is slowly forcing less than half its massive length into your " + assholeDescript() + ".\n\n");
 				outputText("After what seems like hours of Akbal's long cat dick being slowly forced into your " + assholeDescript() + ", your body finally gives out. You've become so exhausted from the strain that you can barely even lift your arms.  With a triumphant growl Akbal thrusts forward, his cockhead spikes burying themselves into you.  Without your resistance, they seem to vibrate inside you like twelve little beads, massaging your innards.  The sudden change makes you croon as you widen your [legs], suddenly desperate for more.");
-			} else if (player.ass.analLooseness < 5) //[Medium pucker]
-			{
+			}
+			else if (player.ass.analLooseness < AssClass.LOOSENESS_GAPING) {
 				outputText("Akbal begins to push into you, the barbs on his massive cockhead causing you to wince as are forcibly stretched.  Without warning, he forces the entirety of his massive length into you in with a snarl.  You almost pass out just from the initial incursion, but as he saws his length in and out, your body reacts of its own accord. You widen your [legs] in an attempt to lessen the sudden slicing pressure created by the barbed cock head.  The moment you stop resisting, the barbs start to vibrate; they start to feel more like humming sex beads than the wicked-looking barbs you know are inside you.  You can't suppress the shuddering and groaning coming from your body as you are hit with a tidal wave of ecstasy.");
 			}
-			//[Gaping pucker]
-			else
-			{
+			else {
 				outputText("Akbal begins to push into you, the barbs on his massive cockhead causing you to wince.  He bottoms out near-instantly, and he looks up at you with a feral grin.  Akbal begins to pump his engorged sex organ in and out of your " + assholeDescript() + " with a steadily mounting force.  You release a groan as the barbs covering Akbal's long cat-dick start to vibrate and begin to feel more like humming sex beads than anything else.  You widen your [legs] in response and Akbal snarls as he slams his hips into you, obviously happy that you're able to take his massive length.  The demon seems to forget that he's raping you; he starts giving your neck licks that send shivers throughout your entire body as he roughly fucks you into the forest floor.");
 			}
 			player.buttChange(new Akbal().cockArea(0), true);
@@ -704,19 +600,11 @@ public class AkbalScene extends BaseContent
 
 			outputText("After hours of being his toy you finally pass out, never having reached your own orgasm.");
 			player.sexReward("cum", "Anal");
-			dynStats("lust+",10 + player.lib / 10,"cor+",5 + rand(10));
+			dynStats("lust+", 10 + player.lib / 10, "cor+", 5 + rand(10));
 		}
 
-		//  AKBAL_TIMES_BITCHED:int = 902;
-
-		//  AKBAL_BITCH_Q:int = 903;
-
-		//Akbal of the Terrestrial Fire [EDITED]
-		//2. AKBAL'S MY BITCH
-
 		//[First Encounter]
-		public function supahAkabalEdition():void
-		{
+		public function supahAkabalEdition():void {
 			spriteSelect(SpriteDb.s_akbal);
 			//Make sure that the buttchange is set correctly
 			//when submitting.  Gotta stretch em all!
@@ -724,23 +612,19 @@ public class AkbalScene extends BaseContent
 			monster.cocks[0].cockLength = 15;
 			monster.cocks[0].cockThickness = 2.5;
 			monster.cocks[0].cockType = CockTypesEnum.HUMAN;
-			if (flags[kFLAGS.AKBAL_BITCH_Q] >= 2)
-			{
+			if (flags[kFLAGS.AKBAL_BITCH_Q] >= 2) {
 				akbitchEncounter();
 				return;
 			}
-			if (flags[kFLAGS.AKBAL_SUBMISSION_STATE] == 2)
-			{
+			if (flags[kFLAGS.AKBAL_SUBMISSION_STATE] == 2) {
 				repeatAkbalPostSubmission();
 				return;
 			}
-			if (flags[kFLAGS.AKBAL_SUBMISSION_STATE] == 1)
-			{
+			if (flags[kFLAGS.AKBAL_SUBMISSION_STATE] == 1) {
 				ackbalRepeatAfterWin();
 				return;
 			}
-			if (flags[kFLAGS.AKBAL_SUBMISSION_STATE] == -1)
-			{
+			if (flags[kFLAGS.AKBAL_SUBMISSION_STATE] == -1) {
 				ackbalRepeatAfterLoss();
 				return;
 			}
@@ -761,8 +645,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Talk]
-		private function superAkbalioTalk():void
-		{
+		private function superAkbalioTalk():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
 			outputText("After a few moments of silence you ask, \"<i>What do you mean, 'submit'?</i>\" Akbal grins, revealing a row of wicked ivory teeth as he opens his mouth. You suddenly feel the demon's powerful body pinning you down, a wide tongue licking your neck and claws tickling your back in a way that is both horrifying and sensual. Yet after a moment of taking it in, you realize that he is still there in front of you, unmoved and grinning. You can guess what the image means: he wants you to become his mate for a day to make up for invading his territory.  What do you do?\n\n");
@@ -772,8 +655,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Encounter if previously submitted]
-		private function repeatAkbalPostSubmission():void
-		{
+		private function repeatAkbalPostSubmission():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
 			outputText("As you walk through the forest, you hear a purring coming from behind you.  Turning around reveals that Akbal has come to find you.  He uses his head to push you in the direction of his territory, obviously wanting to dominate you again.\n\n");
@@ -783,8 +665,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Deny]
-		private function akbalDeny():void
-		{
+		private function akbalDeny():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
 			outputText("You shake your head and rub the lust-filled jaguar behind the ear as you tell him you're busy.  The demon's eyes roll, and he licks your [leg] before his eyes find an imp in the trees above the two of you.\n\n");
@@ -793,8 +674,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Encounter if previously fought and won/raped him]
-		private function ackbalRepeatAfterWin():void
-		{
+		private function ackbalRepeatAfterWin():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
 			outputText("As you walk through the forest, you hear a snarl and look up just in time to dodge a surprise attack by the jaguar demon, Akbal.  Your ");
@@ -807,8 +687,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Encounter if previously fought and lost]
-		private function ackbalRepeatAfterLoss():void
-		{
+		private function ackbalRepeatAfterLoss():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
 			outputText("A chorus of laughter sounds inside your mind as the jaguar demon, Akbal, drops to the ground in front of you.  His masculine voice says, \"<i>Well, if it isn't the defiant welp who, in all their great idiocy, has wandered into my territory again.  Will you submit, or do I have to teach you another harsh lesson?</i>\"\n\n");
@@ -818,8 +697,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Fight]
-		private function startuAkabalFightomon():void
-		{
+		private function startuAkabalFightomon():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
 			outputText("You ready your [weapon] and prepare to battle the demon jaguar.");
@@ -829,23 +707,20 @@ public class AkbalScene extends BaseContent
 		}
 
 		//[Submit]
-		private function akbalSubmit():void
-		{
+		private function akbalSubmit():void {
 			spriteSelect(SpriteDb.s_akbal);
 			player.slimeFeed();
 			flags[kFLAGS.AKBAL_SUBMISSION_COUNTER]++;
 			flags[kFLAGS.AKBAL_SUBMISSION_STATE] = 2;
 			flags[kFLAGS.AKBAL_BITCH_Q] = -1;
 			//Big booty special
-			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] > 5 && flags[kFLAGS.PLAYER_RESISTED_AKBAL] < 2 && player.butt.type >= 13 && player.tone < 80)
-			{
+			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] > 5 && flags[kFLAGS.PLAYER_RESISTED_AKBAL] < 2 && player.butt.type >= 13 && player.tone < 80) {
 				akbalBigButtSubmit();
 				return;
 			}
 			clearOutput();
 			//Naga variant goez here
-			if (player.isNaga())
-			{
+			if (player.isNaga()) {
 				outputText(images.showImage("akbal-deepwoods-naga-sumbitanal"));
 				outputText("After a few moments of thinking you nod to Akbal and the masculine voice in your head commands you to disrobe. You take off your [armor], setting it aside moments before the demon is upon you.\n\n");
 
@@ -859,22 +734,19 @@ public class AkbalScene extends BaseContent
 				outputText("A sudden warmth heats your innards, making you shiver in ecstasy.  Akbal takes a moment to uncoil your bottom half from around his chest before he rises to mount you. A single paw shoves your lifted chest and face back into the dirt, causing cold earth to cling to your body as Akbal gets into position above you.\n\n");
 
 				//(Small/Virgin Pucker)
-				if (player.ass.analLooseness < 3)
-				{
+				if (player.ass.analLooseness < 3) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only insanely large but its head is covered in a dozen tiny barbs. You grit your teeth, expecting pain and yet, thanks to the weird saliva he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 
 					outputText("The feeling of being stretched by Akbal's long, slimy member makes you shudder, the weird spit even heats up, creating a steamy warmth inside you as Akbal's equally hot member stretches you out and makes your body spasm slightly. After a few slow, shallow strokes you begin to feel the barbs vibrate. This vibrating drives you insane, and the wicked looking barbs feel more like humming sex beads than punishing spikes. When Akbal picks up the pace you grit your teeth as you are stretched beyond your natural limits.");
 				}
 				//(Medium Pucker)
-				else if (player.ass.analLooseness < 5)
-				{
+				else if (player.ass.analLooseness < 5) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs. Yet, thanks to the weird spit he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 
 					outputText("Akbal's titanic member stretches your " + assholeDescript() + " and makes you groan beneath him, reveling in the slick heat and fullness of your bowels. His saliva heats up, creating a steamy,pleasurable warmth inside your body. As he begins to pump his huge sex organ in and out of you the barbs covering his head begin to vibrate and hit your body with tidal waves of unbearable pleasure, feeling more like vibrating sex beads than punishing spikes. Your body begins to act of its own accord, your [butt] grinding against his thrusts as his large sex pump slides in with his trunk slamming into your [butt] in rhythmic, echoing claps.");
 				}
 				//(Gapping Pucker - Akbal's dick = 15 inches)
-				else
-				{
+				else {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs. When Akbal begins to penetrate you he is surprised when his trunk suddenly slams into your [butt], the sudden invasion causing you to croon.\n\n");
 
 					outputText("The weird spit he slathered your insides with begins to heat up instantly and the barbs covering his cock head start vibrating. The sensation of the vibrating barbs is like a dozen small slimy sex beads spinning and shaking as they are pushed inside you. Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing your body to slide forward through the dirt. You try to meet his deep thrusts but the jaguar fucks you with speed and force befitting a cheetah and the constantly vibrating barbs make your body shiver with each hammer blow to your insides.");
@@ -894,10 +766,9 @@ public class AkbalScene extends BaseContent
 				dynStats("cor", 4 + rand(8));
 				//[+ 1-2 Speed]
 				dynStats("spe", 1 + rand(2));
-				player.sexReward("cum","Anal");
+				player.sexReward("cum", "Anal");
 				//[Chance of butt growth]
-				if (player.butt.type < 8)
-				{
+				if (player.butt.type < 8) {
 					outputText("\n\nIn your sleep, your ass plumps up slightly, growing to accomodate the demon's wishes...");
 					player.butt.type++;
 				}
@@ -906,8 +777,7 @@ public class AkbalScene extends BaseContent
 				return;
 			}
 			//Taur variant goez here
-			if (player.isTaur())
-			{
+			if (player.isTaur()) {
 				outputText(images.showImage("akbal-deepwoods-taur-sumbitanal"));
 				outputText("After a few moments of thinking you nod to Akbal.  The deep voice in your head commands you to disrobe.  You take off your [armor], setting it aside while mentally preparing yourself for whatever this demon has in mind.\n\n");
 
@@ -937,20 +807,17 @@ public class AkbalScene extends BaseContent
 
 				//(Small/Virgin Pucker)
 				//[Small/virgin pucker]
-				if (player.ass.analLooseness < 3)
-				{
+				if (player.ass.analLooseness < 3) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only insanely large but its head is covered in a dozen tiny barbs.  You grit your teeth, expecting pain and yet, thanks to the weird saliva he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 					outputText("The feeling of being stretched by Akbal's long, slimy member makes you shudder.  The weird spit even heats up which creates a steamy warmth inside you as Akbal's hot member makes your body spasm slightly.  After a few slow, shallow strokes you begin to feel the barbs vibrate.  This vibrating sends your body into convulsions, the wicked-looking barbs feel more like humming sex beads than punishing spikes.  When Akbal picks up the pace you grit your teeth as you are stretched beyond your natural limits.");
 				}
 				//(Medium Pucker)
-				else if (player.ass.analLooseness < 5)
-				{
+				else if (player.ass.analLooseness < 5) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs.  Yet,  thanks to the weird spit he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 					outputText("Akbal's titanic member stretches your " + assholeDescript() + " and makes you groan and claw at the tree he has you pressed against, reveling in the slick heat and fullness of your bowels.  His saliva heats up, creating a steamy yet pleasurable warmth inside your body.  As he begins to pump his huge sex organ in and out of you the barbs covering his head begin to vibrate and hit your body with tidal waves of unbearable pleasure, feeling more like vibrating sex beads than punishing spikes.  You lean back into his thrusts as his trunk begins slamming into your [butt] in rhythmic claps that echo throughout the forest.");
 				}
 				//(Gapping Pucker - Remember Akbal's dick is 15 inches)
-				else
-				{
+				else {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs.  When Akbal begins to penetrate you he groans in surprise as his large dick sinks into your [butt] easily, the sudden invasion causing you to croon.\n\n");
 					outputText("The weird spit he slathered your insides with begins to heat up instantly and the barbs covering his cock head start vibrating.  The sensation is like a dozen small slimy sex beads spinning and shaking as they are pushed inside you.  Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing the tree you're shoved up against to shake back and forth.  You try to meet his deep thrusts but the jaguar fucks you with speed and force befitting a cheetah and the constantly vibrating barbs make your body shiver with each hammer blow to your insides.");
 				}
@@ -974,8 +841,7 @@ public class AkbalScene extends BaseContent
 				dynStats("spe", 1 + rand(2));
 				player.sexReward("cum", "Anal");
 				//[Chance of butt growth]
-				if (player.butt.type < 8)
-				{
+				if (player.butt.type < 8) {
 					outputText("\n\nIn your sleep, your ass plumps up slightly, growing to accomodate the demon's wishes...");
 					player.butt.type++;
 				}
@@ -994,13 +860,11 @@ public class AkbalScene extends BaseContent
 			outputText("He suddenly yanks your upturned bottom half toward himself and shoves his face into your [butt].  His slippery wet tongue begins to work its way into your " + assholeDescript() + ", greedily lapping at your exposed backside as though it were a quickly-melting ice cream cone.  The sensation causes you to groan and grind against the tongue, quickly losing yourself into ecstasy.  You spread your [legs] and arch your back, allowing his long and thick jaguar tongue to drill deeper into your " + assholeDescript() + ".  You feel his thick and warm saliva sliding into you and coating your insides.\n\n");
 
 			//[Player has a vagina]
-			if (player.hasVagina())
-			{
+			if (player.hasVagina()) {
 				outputText("Akbal slurps his way down to your " + vaginaDescript(0) + ", twisting his face and drilling his tongue into you, mercilessly attacking your " + clitDescript() + " as you scream, howl and cringe from the stimulation.  He then gently sucks your " + clitDescript() + " into his mouth and twirls his tongue around it, making you grind your swollen sex against his jaguar lips.  ");
 			}
 			//[Player has balls]
-			else if (player.balls > 0)
-			{
+			else if (player.balls > 0) {
 				outputText("Akbal slurps his way down to your " + sackDescript() + ", slathering his heated saliva over your orbs and making you groan as your sensitive [balls] are teased and gently juggled by Akbal's masterful tongue.  Your body continually twitches with pleasure from the sensations.  ");
 			}
 
@@ -1008,8 +872,7 @@ public class AkbalScene extends BaseContent
 
 			outputText("You feel him poking around your " + assholeDescript() + ", learning quickly that not only is his member insanely large, but its head is covered in dozens of tiny barbs.  ");
 			//[Small/virgin pucker]
-			if (player.ass.analLooseness < 3)
-			{
+			if (player.ass.analLooseness < 3) {
 				outputText("You grit your teeth, expecting pain. However, thanks to the weird saliva he slathered your innards with, you feel none as his gargantuan member forcibly widens your " + assholeDescript() + ".");
 				player.buttChange(monster.cockArea(0), true);
 				outputText("\n\n");
@@ -1017,8 +880,7 @@ public class AkbalScene extends BaseContent
 				outputText("Being stretched by Akbal's long and slick member makes you shudder. The weird spit even begins to heat up, creating a steamy warmth inside you as Akbal's equally hot member stretches you out, your body spasming slightly in response.  After a few slow and shallow strokes, you can feel the barbs begin to vibrate.  The sudden motion sends your body into convulsions, the wicked-looking barbs acting more like humming sex beads than barbs.  When Akbal picks up the pace, you can only grit your teeth harder as you're stretched more and more beyond your natural limits.\n\n");
 			}
 			//[Medium Pucker]
-			else if (player.ass.analLooseness < 5)
-			{
+			else if (player.ass.analLooseness < 5) {
 				outputText("Thanks to the weird saliva he slathered your innards with, you feel no pain as his gargantuan member forcibly widens your " + assholeDescript() + ".");
 				player.buttChange(monster.cockArea(0), true);
 				outputText("\n\n");
@@ -1026,8 +888,7 @@ public class AkbalScene extends BaseContent
 				outputText("Akbal's titanic member stretching your " + assholeDescript() + " makes you groan beneath him, reveling in the slick heat and the fullness of your bowels.  His saliva heats up, creating a steamy and pleasurable warmth inside your body.  As he begins to pump his huge member in and out of you, the barbs covering his head begin to vibrate.  Your body is hit with waves of unbearable pleasure, the wicked-looking barbs acting more like humming sex beads than barbs.  Your body begins to act of its own accord; your [butt] grinds against his thrusts as his large sex slides in, his trunk slamming into your [butt] with rhythmic claps that echo throughout the forest.\n\n");
 			}
 			//[Gapping Pucker - Remember Akbal's dick is 15 inches]
-			else
-			{
+			else {
 				outputText("As Akbal begins to penetrate you, he groans in surprise at how easily his large dick sinks into your [butt], and the sudden invasion causes you to croon.\n\n");
 
 				outputText("The weird spit he slathered your insides with instantly heats up, and the barbs covering his cock head suddenly start vibrating.  The vibrating barbs feel like slimy sex beads, spinning and shaking as they are pushed inside you.  Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing your body to slide forward through the dirt.  You try to meet his deep thrusts, but the jaguar is fucking you with speed and force befitting a cheetah. The constantly vibrating barbs make your body shiver with each hammering blow to your insides.\n\n");
@@ -1052,10 +913,9 @@ public class AkbalScene extends BaseContent
 			dynStats("cor", 4 + rand(8));
 			//[+ 1-2 Speed]
 			dynStats("spe", 1 + rand(2));
-			player.sexReward("cum","Anal");
+			player.sexReward("cum", "Anal");
 			//[Chance of butt growth]
-			if (player.butt.type < 8)
-			{
+			if (player.butt.type < 8) {
 				outputText("\n\nIn your sleep, your ass plumps up slightly, growing to accomodate the demon's wishes...");
 				player.butt.type++;
 			}
@@ -1066,24 +926,19 @@ public class AkbalScene extends BaseContent
 		//[General End]
 		//Set flag after submitting, then clear it and run
 		//this before going to camp?
-		public function akbalSubmissionFollowup():void
-		{
+		public function akbalSubmissionFollowup():void {
 			spriteSelect(SpriteDb.s_akbal);
 			clearOutput();
-			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] < 4)
-			{
+			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] < 4) {
 				outputText("You awake in your camp feeling dangerous, powerful and fiercely satisfied.");
 			}
-			//[After 8th submission, if whispered and corruption is greater than 80%]
+				//[After 8th submission, if whispered and corruption is greater than 80%]
 			//(fighting Akbal disables this scene, but you retain the ability if you rape him after)
-			else if (flags[kFLAGS.PLAYER_RESISTED_AKBAL] == 0 && flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] >= 8 && player.cor > 80)
-			{
-				if (player.cor < 80 || player.hasPerk(PerkLib.FireLord))
-				{
+			else if (flags[kFLAGS.PLAYER_RESISTED_AKBAL] == 0 && flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] >= 8 && player.cor > 80) {
+				if (player.cor < 80 || player.hasPerk(PerkLib.FireLord)) {
 					outputText("You awake in your camp feeling dangerous, powerful and fiercely satisfied.");
 				}
-				else
-				{
+				else {
 					outputText("You open your eyes and almost yell in surprise when you see Akbal's emerald eyes looking into yours.  You are still in the forest and his lithe jaguar body is still over you; you quickly realize he hasn't moved you, as you're still resting in a puddle of mixed sex juices.\n\n");
 					outputText("\"<i>You are a loyal pet,</i>\" Akbal says as he stands. The compliment makes you smile, but it quickly fades into a look of fear when he suddenly releases a bone-chilling roar right in your face.  Green flames begin to pour from his open maw, and you scream as you flail your hands in a pointless attempt to block the fire.\n\n");
 					outputText("After a moment of horror, you realize you aren't burning.  You can feel the emerald flames inside your lungs, glowing with a palpable warmth.  Akbal snaps his teeth together, a feral grin on his face as he halts the torrent of flame.\n\n");
@@ -1095,15 +950,13 @@ public class AkbalScene extends BaseContent
 				}
 			}
 			//[After 4th submission if corruption is greater than 40%]
-			else if (!player.hasPerk(PerkLib.Whispered) && player.cor >= 40)
-			{
+			else if (!player.hasPerk(PerkLib.Whispered) && player.cor >= 40) {
 				outputText("You awake in your camp with Akbal standing over you, the chorus of voices in your head reaching the apex of an agonizingly beautiful song, and then falling silent.  When you rise, Akbal licks your face before turning away and sprinting into the forest.\n\n");
-				if (!player.hasPerk(PerkLib.Whispered))
-				{
+				if (!player.hasPerk(PerkLib.Whispered)) {
 					outputText("(You are now Whispered.)");
 					player.createPerk(PerkLib.Whispered, 0, 0, 0, 0);
-						//['Whispered' appears as perk]
-						//[Gain 'Whisper' in Specials]
+					//['Whispered' appears as perk]
+					//[Gain 'Whisper' in Specials]
 				}
 			}
 			else
@@ -1123,8 +976,7 @@ public class AkbalScene extends BaseContent
 		   Evasion+5
 		 */
 
-		private function akbalBigButtSubmit():void
-		{
+		private function akbalBigButtSubmit():void {
 			clearOutput();
 			outputText(images.showImage("akbal-deepwoods-bigbuttanaled"));
 			outputText("Smiling in anticipation of servicing the jaguar-lord once more, you remove your [armor] and drop down to all fours, slowly lowering your face down to the ground.  You give your [butt] a slow back-and-forth wiggle as your cheek comes to rest on the dirt, degrading yourself for your demon-god's enjoyment.");
@@ -1150,14 +1002,11 @@ public class AkbalScene extends BaseContent
 			else if (player.hasVagina())
 				outputText("  Your [vagina] is dripping freely by this point, and though Akbal doesn't bother with it, the feelings radiating from his warm pole seem to reach all the way through your pulsing pussy to your [clit], rigid and soaked as it is.");
 			outputText("  Suddenly, that blessed tool departs from your over-sensitive innards, only to return a moment later, plunged back in with a firm, measured stroke.   You squeal as another precision stroke of the demonic jaguar shaft bottoms out into your [asshole] once more, the thrust teasing an orgasm from your pleasure wracked body");
-			if (player.hasCock())
-			{
+			if (player.hasCock()) {
 				outputText(", your [cock] freely unleashing its load into the mud beneath you and tainting the ground with your wasted cum");
-				if (player.cumQ() >= 500)
-				{
+				if (player.cumQ() >= 500) {
 					outputText(" as it puddles around you");
-					if (player.cumQ() >= 1000)
-					{
+					if (player.cumQ() >= 1000) {
 						if (player.cumQ() < 3000)
 							outputText(" into a small lake");
 						else
@@ -1165,8 +1014,7 @@ public class AkbalScene extends BaseContent
 					}
 				}
 			}
-			else if (player.hasVagina())
-			{
+			else if (player.hasVagina()) {
 				outputText(", ");
 				if (player.wetness() >= 4)
 					outputText("squirting ");
@@ -1185,13 +1033,11 @@ public class AkbalScene extends BaseContent
 			if (player.hasCock() && player.cumQ() >= 1000)
 				outputText("dry, ");
 			outputText("comfortable place.  Akbal wraps his arms around you, though one steals a quick squeeze of your [butt].  Invigorated by this, he docks his cat-cock back inside your spunk-oozing asshole to plug it and snuggles up to you.  You fall asleep like that, dreaming of him taking you again and again.");
-			if (player.butt.type < 20)
-			{
+			if (player.butt.type < 20) {
 				outputText("  Tingling in your sleep, your [butt] bulges slightly as it grows bigger, changed by Akbal's saliva to serve him even more capably.");
 				player.butt.type++;
 			}
-			else if (player.tone > 30)
-			{
+			else if (player.tone > 30) {
 				outputText("  Tingling in your sleep, your [butt] jiggles slightly as it softens along with the rest of your body, changed by Akbal's saliva to be a softer, more pleasant fuck.");
 				player.modTone(30, 5);
 			}
@@ -1205,17 +1051,15 @@ public class AkbalScene extends BaseContent
 		//By Foxxling
 		//Akbal’s My Bitch Expansion
 		//Auto Rape Intro Scene
-		private function akbitchEncounter():void
-		{
+		private function akbitchEncounter():void {
 			clearOutput();
 			outputText("As you explore the deep woods you begin to hear a soft slurping sound. In this world you know that any strange sound, especially the wet ones, most likely means something dangerous is up ahead... or something dangerous is fucking something a little less dangerous.  As you cautiously advance you spy the pelt of the jaguar demon, Akbal.  The demon jaguar sits in the middle of the clearing with one leg extended as he repeatedly swipes his wide tongue against his hole, probably cleaning up imp spunk thanks to you.  He is so utterly focused on the task that he doesn’t notice your approach.");
 			flags[kFLAGS.AKBAL_BITCH_Q] = 1;
-			//{corruption < 40/choose no}
-			if ((player.cor < 40 && flags[kFLAGS.MEANINGLESS_CORRUPTION] <= 0 && !player.hasPerk(PerkLib.Pervert) && !player.hasPerk(PerkLib.Sadist)) || player.lust < 33)
+			if ((player.cor < 40 + player.corruptionTolerance && !player.hasPerk(PerkLib.Pervert) && !player.hasPerk(PerkLib.Sadist)) || player.lust < 33) {
+				sceneHunter.print("Check failed: (high corruption or Pervert/Sadist perk) + high lust")
 				akbitchNoThnx(false);
-			//{corruption > 40}
-			else
-			{
+			}
+			else {
 				outputText("\n\nDo you take advantage of him again?");
 				menu();
 				addButton(1, "No", akbitchNoThnx);
@@ -1223,8 +1067,7 @@ public class AkbalScene extends BaseContent
 			}
 		}
 
-		private function akbitchNoThnx(clear:Boolean = true):void
-		{
+		private function akbitchNoThnx(clear:Boolean = true):void {
 			if (clear)
 				clearOutput();
 			else
@@ -1236,8 +1079,7 @@ public class AkbalScene extends BaseContent
 		}
 
 		//{Choose Rape}
-		public function takeAdvantageOfAkbitch():void
-		{
+		public function takeAdvantageOfAkbitch():void {
 			clearOutput();
 			outputText("You creep behind the many woods trees surrounding Akbal’s clearing until your eyes chance upon a vine.  It’s spongy, long, and hard to rip apart - in other words: perfect.");
 
@@ -1250,8 +1092,8 @@ public class AkbalScene extends BaseContent
 			outputText("\n\nOnce you’re in range, you take the vine in your hand and tackle the unsuspecting demon’s back with a snarl.");
 
 			//(strength < 50)
-			if (player.str < 50)
-			{
+			if (player.str < 50) {
+				sceneHunter.print("Failed attribute check: STR.");
 				outputText("\n\nA gout of green fire roars into existence.  The suddenly intense heat causes you to flinch away from the inferno nearly encasing your [face].  The jaguar demon slips your grasp, and when you look up, another green fireball is coming your way.  Looks like you have a fight on your hands.\n\n");
 				//(Enter battle with clearscreen and fireball attack.)
 				var akbal:Akbal = new Akbal();
@@ -1263,205 +1105,175 @@ public class AkbalScene extends BaseContent
 			outputText("\n\nA gout of green fire roars into existence.  With little effort, you slam Akbal’s head into the ground. The plume of emerald fire roars across the forest floor, burning nothing but vegetation and bugs. While holding him down with your body and one hand, you grab your vine.  After tying the demon’s arms together, his body begins to shift beneath you, becoming the humanoid form you have come to associate with his aroused state.  Despite the ferocity with which he struggles, you can plainly see he is turned on.  Thanks to his slim build, it's easy for you to out-muscle him. You can almost ignore the way he keeps bucking, trying to throw you off, and keep him pinned.");
 
 			//{Intelligence < 60}
-			if (player.inte < 60)
-			{
-				outputText("\n\nAkbal suddenly stops struggling and you hear someone shout your name.  As you look away Akbal rolls from beneath you.  A blast of terrestrial ignites the vines and he lunges at you, his claws extended.\n\n");
+			if (player.inte < 60) {
+				sceneHunter.print("Failed attribute check: INT.");
+				outputText("\n\nAkbal suddenly stops struggling, and you hear someone shouts your name.  As you look away Akbal rolls from beneath you.  A blast of terrestrial ignites the vines, and he lunges at you, his claws extended.\n\n");
 				//(fight - clearscreen and enemyattack)
 				startCombat(new Akbal());
 				monster.eAttack();
 				return;
 			}
 			//{intelligence > 60}
-			outputText("\n\nAkbal suddenly stops struggling and you hear someone shout your name. You smile, knowing the voice is Akbal’s attempt to distract you.  Ignoring his desperate ploy, you grab the demon by the shoulders and slam him into the ground.  He struggles, you push him down again.  After throwing a fit of swearing and cursing, he goes limp.  Accepting his fate, he tells you to get on with it.  With his arms still behind his back, you tie a portion of the vine around his neck like a collar and leave the rest hanging from the main part, resembling a leash.  This is going to be fun.");
+			outputText("\n\nAkbal suddenly stops struggling, and you hear someone shouts your name. You smile, knowing the voice is Akbal’s attempt to distract you.  Ignoring his desperate ploy, you grab the demon by the shoulders and slam him into the ground.  He struggles, you push him down again.  After throwing a fit of swearing and cursing, he goes limp.  Accepting his fate, he tells you to get on with it.  With his arms still behind his back, you tie a portion of the vine around his neck like a collar and leave the rest hanging from the main part, resembling a leash.  This is going to be fun.");
+			sceneHunter.print("Forks for dick size, type(horse/tentacle/lizard/dragon/cat/knot), vagina tight/loose/gaping - everywhere!");
 
 			flags[kFLAGS.AKBAL_TIMES_BITCHED]++;
 			menu();
-			addButton(0, "Normal", basicAkbitchScene);
-			//AMB Strength Scene
-			//70+
-			if (player.str >= 70)
-				addButton(1, "Strong", akbitchHighStrengthVariant);
-			//AMB Speed Scene
-			//70
-			if (player.spe >= 70)
-				addButton(2, "Fast", akbalBitchSpeed);
-			//AMB Toughness Scene
-			//70
-			if (player.tou >= 70)
-				addButton(3, "Toughness", akbitchToughness);
+			//normal
+			addButton(0, "Normal", basicAkbitch);
+			addButtonIfTrue(1, "Strong", akbitchStrength, "Not strong enough.", player.str >= 70);
+			addButtonIfTrue(2, "Fast", akbitchSpeed, "Not fast enough.", player.spe >= 70);
+			addButtonIfTrue(3, "Tough", akbitchToughness, "Not tough enough.", player.tou >= 70);
 		}
 
 		//Basic AMB Scene (no +70 stats)
-		private function basicAkbitchScene():void
-		{
+		private function basicAkbitch():void {
 			clearOutput();
 			outputText("With a grin, you tug on Akbal’s collar, and he lets out a barely suppressed purr.  ");
 			if (flags[kFLAGS.AKBAL_TIMES_BITCHED] == 1)
-				outputText("The smile on your [face] spreads even wider as the unexpected sound tells you you’ve turned this demonic sexual predator into your own personal slut.  As if to confirm this, h");
+				outputText("The smile on your [face] spreads even wider as the unexpected sound tells you that you’ve turned this demonic sexual predator into your own personal slut.  As if to confirm this, h");
 			else
 				outputText("H");
-			outputText("e lifts his tail, giving you a perfect view of his entire package, from his self-lubing sphincter to his full balls, and rock-hard, demon-cat dick.  Through lust, his will has been broken, and now he is yours.");
-			outputText("\n\nWhat will you do with him?");
+			outputText("e lifts his tail, giving you a perfect view of his entire package, from his self-lubing sphincter to his full balls, and rock-hard, demon-cat dick.  Through lust, his will has been broken, and now he is yours.\n\n");
+			sceneHunter.passCheckOnce();
+			sceneHunter.selectGender(
+				curry(sceneHunter.callBigSmall, dickF, 12, 7, "length", 20), vagF, null, null, 1,
+				player.cockThatFits(20, "length") >= 0, "Too big! (Req. a dick shorter than 20 inches)");
 
-			menu();
-			if (player.hasCock())
-				addButton(0, "Fuck Him", buttFuckbuttFuckbuttFuckAkbal);
-			addButton(1, "Ride Him", topAkbitchFromDaBottom);
-		}
-
-		//Butt Fuck - Vaginal - Anal
-		private function buttFuckbuttFuckbuttFuckAkbal():void
-		{
-			clearOutput();
-			outputText(images.showImage("akbal-deepwoods-male-buttfuck"));
-			//[if (hasCock = true)]
-			if (player.hasCock())
-				outputText("You widen your stance as you sink into the demon’s moist depths with a grin.");
-			if (player.cockTotal() > 1)
-				outputText("  You widen your stance and look down, choosing the biggest among [eachCock].");
-			outputText("  You lift your [cock biggest] into position, and with a grin, you begin to push into the demon’s moist depths.");
-
-			var x:int = player.biggestCockIndex();
-
-			//{if penis < 7 inches}
-			if (player.cocks[x].cockLength < 7)
-				outputText("\n\nAkbal croons, and you find yourself wondering why he even bothered resisting in the first place.  You tug his forest-made collar and Akbal begins obediently fucking himself on your [cock biggest].  You’re able to lean back and relax as the demon fucks himself using your [cock biggest].  When he slows down, a sudden smack to his muscular hind-end puts him right back on track.  The naturally lubricated hole even pulses, squeezing your [cock biggest] as Akbal takes every inch you have to offer with a grin on his face.");
-			//{If penis = 7in-12in}
-			else if (player.cocks[x].cockLength < 12)
-				outputText("\n\nAkbal groans deep in his chest as you invade his lube-dripping tailhole. He begins to pull away from your [cock biggest] as you push forward.  A sharp tug on his collar corrects this and you resume your efforts to enter his body.  Once your [cockHead biggest] is inside him, he swoons and pushes his muscular rump back onto your [cock biggest] without need for further instruction.  Every time your full length slides into him, he gives a sharp yelp, a hungry sound that shows both his tightness and his need for your [cock biggest].  He maintains a fevered pace and even throws his head back as he pleasures himself on your [cock biggest].");
-			//{if penis > 12in}
-			else
-				outputText("\n\nAkbal howls and cringes as you begin to stuff yourself into his tight tailhole.  His hips swerve and you have to yank your forest-made collar to keep your [cock biggest] buried within his gloriously wet and unbelievably tight hole.  Once you’ve managed to get your [cockHead biggest] past his tight ring, he begins to whine again.  You have to pull his collar to force him down the length of your [cock biggest], but once a foot of your massive dick is inside him, your advance is halted.  Before you even think to complain his insides begin to squirm, shifting to make room for the rest of your [cock biggest].  You reach down and grab his hips, pulling him back until his plump muscled cheeks softly mash against your trunk.  He howls as you maintain a firm grip on his slender hips, not allowing him to move an inch.  Through your fully embedded [cock biggest] you can feel his hole quivering as it pumps massive gobs of that creamy, slick lube in an attempt to make the fuck easier.  A yank on the collar causes the demon to begin slowly forcing himself up and down the length of your [cock biggest].  After a few incursions Akbal picks up the pace and becomes lost in fucking himself up and down your giant pole.  His natural lube even slides out and drips down your [legs] as he repeatedly smashes his insatiable ass into you.  Unbidden, a groan finds its way out your mouth as the demon works you over, having gone from neophyte to pro in a matter of minutes.");
-
-			menu();
-			addButton(0, "Next", fuckAkbitchsButt);
-		}
-
-		//- page turn -
-		private function fuckAkbitchsButt():void
-		{
-			clearOutput();
-			var x:int = player.biggestCockIndex();
-			outputText(images.showImage("akbal-deepwoods-male-buttfuck2"));
-			outputText("Without warning, Akbal’s insides become vacuum tight.  Convulsions rocket through his body and you realize he has reached his climax without any attention to his barbed dick.  ");
-			if (player.cor < 90)
-				outputText("You hold the demon’s make-shift collar, letting him ride out his orgasm as he cries out in pure ecstasy, reveling in the satisfaction of knowing you have made him your bitch.");
-			else
-				outputText("You pound your bitch’s quivering rectum, reveling in the pulsating pressure as Akbal roars beneath you, a sound of mixed pain and ecstasy as you decimate his clenching hole with brutal thrusts.");
-
-			outputText("\n\nSoon you feel that familiar pressure building. Bearing down on him, you begin to slam into his thrusts and enjoy the demon’s snarling, his tail curling every time your two bodies meet with a loud clap.");
-
-			//{if player has dog cock + knot}
-			if (player.hasKnot(x))
-				outputText("\n\nYou meet your new bitch’s ass with a clap of your hips, sawing your [cock biggest] in and out of his gloriously tight hole.  He howls as you force your swollen knot into his back door with an audible pop.  He reacts by falling flat against the ground in an attempt to get away from the sudden extra girth invading his tailhole, pulling you with him. With your arms wrapped around his you howl and grind your exploding [cock biggest] into his corked bowels, filling the demon body full of hot seed, causing his stomach to swell slightly.");
-			//{if player has horse cock}
-			else if (player.cocks[x].cockType == CockTypesEnum.HORSE)
-				outputText("\n\nAs your shaft splits Akbal in two, he somehow can’t even begin to keep up with the renewed viciousness of your pounding [cock biggest].  One deep, soul shattering thrust causes Akbal to spit fire as you yank his collar and hold, pouring baby batter into his bowels until it spills from the brutally stretched hole, around your [cock biggest] in streams of thick white goo.");
-			//{if player has tentacle dick}
-			else if (player.cocks[x].cockType == CockTypesEnum.TENTACLE)
-				outputText("\n\nSuddenly your [cock biggest] goes wild.  Akbal is howling as his bowels are rearranged by your [cock biggest].  Looking down you can see your [cock biggest] moving around beneath his skin and fur.  When the first spurts of your orgasm begin to fire into his dancing bowels, Akbal pushes back, smashing himself into you as he is hit by a second orgasm thanks to your [cock biggest] agitating his very swollen and very abused prostate.");
-			//{if player has cat dick}
-			else if (player.cocks[x].cockType == CockTypesEnum.CAT)
-				outputText("\n\nAkbal seems particularly fond of your [cock biggest] as he dances on its rigid length.  When your embedded [cock biggest] begins to spurt hot seed into the demon’s bowels you take control and start mercilessly slamming your [hips] into the jaguar's upturned back side.  He shivers as you beat out a titanic orgasm.  Even after you are spent, he continues to grind against your [cock biggest].");
-			//{if player has human/kanga dick}
-			else
-				outputText("\n\nYou pull on the collar and fall forward.  You begin to blast hot seed into Akbal’s shivering bowels while continuing to pound him into submission, the collar clenched in your fist as you beat out your orgasm, streams of baby batter running down the bitch’s legs and scrotum.");
-
-			outputText("\n\nYou look back at your new bitch with a grin while he regains his senses.  As you leave the forest you hear a promise from Akbal’s chorus of voices, \"<i>You will regret this... Champion.</i>\"");
-
-			player.sexReward("Default","Dick",true,false);
-			dynStats("cor", 3);
-			doNext(camp.returnToCampUseOneHour);
-		}
-
-		private function topAkbitchFromDaBottom():void
-		{
-			clearOutput();
-			outputText(images.showImage("akbal-deepwoods-male-akbalonback"));
-			//[{if goo legs}]
-			if (player.isGoo())
-				outputText("You lay down in the soft grass with a mischievous grin.  Using the collar, you yank Akbal forward, causing his mouth to splash into your [vagOrAss].  Instantly your entire form feels as if waves of pure ecstasy are cascading through you.  The feeling peaks and recedes in an unpredictable pattern and you’re lost in the feel of the demon’s mystic saliva as you ride out your orgasm, reveling in the heat of his tongue coated in that wonderful spit.  When you can stand it no more, you push the demon onto his back and look upon his rigid tool as it leaks and quivers while pointing to the sky.");
-			//[if (biped = true)
-			else
-			{
-				outputText("You lay down in the soft grass with the collar in hand.  You wrap your arms around your [legs], holding them up to give the demon an easier target.  With a light tug the demon takes the hint and smashes his face into your [vagOrAss].  The sensations coursing through your body as his tongue flitters across your ");
-				if (player.hasVagina())
-					outputText("clit");
+			//==========================================================================================================
+			function dickF(x:int):void {
+				var x1:int = x + 1; //for output
+				outputText(images.showImage("akbal-deepwoods-male-buttfuck"));
+				outputText("  You lift your [cock " + x1 + "] into position, and with a grin, you begin to push into the demon’s moist depths.");
+				//{if penis < 7 inches}
+				if (player.cocks[x].cockLength < 7)
+					outputText("\n\nAkbal croons, and you find yourself wondering why he even bothered resisting in the first place.  You tug his forest-made collar and Akbal begins obediently fucking himself on your [cock " + x1 + "].  You’re able to lean back and relax as the demon fucks himself using your [cock " + x1 + "].  When he slows down, a sudden smack to his muscular hind-end puts him right back on track.  The naturally lubricated hole even pulses, squeezing your [cock " + x1 + "] as Akbal takes every inch you have to offer with a grin on his face.");
+				//{If penis = 7in-12in}
+				else if (player.cocks[x].cockLength < 12)
+					outputText("\n\nAkbal groans deep in his chest as you invade his lube-dripping tailhole. He begins to pull away from your [cock " + x1 + "] as you push forward.  A sharp tug on his collar corrects this, and you resume your efforts to enter his body.  Once your [cockHead biggest] is inside him, he swoons and pushes his muscular rump back onto your [cock " + x1 + "] without need for further instruction.  Every time your full length slides into him, he gives a sharp yelp, a hungry sound that shows both his tightness and his need for your [cock " + x1 + "].  He maintains a fevered pace and even throws his head back as he pleasures himself on your [cock " + x1 + "].");
+				//{if penis > 12in}
 				else
-					outputText("prostate");
-				outputText(" makes you cringe.  Your new toy laps at your [vagOrAss] and sends shivers coursing through your body as your [vagina] becomes drenched.  Something about his saliva causes an almost electric sensation to shoot through you. When you can stand it no more, you push the demon onto his back and look upon his rigid tool as it quivers.");
+					outputText("\n\nAkbal howls and cringes as you begin to stuff yourself into his tight tailhole.  His hips swerve, and you have to yank your forest-made collar to keep your [cock " + x1 + "] buried within his gloriously wet and unbelievably tight hole.  Once you’ve managed to get your [cockHead biggest] past his tight ring, he begins to whine again.  You have to pull his collar to force him down the length of your [cock " + x1 + "], but once a foot of your massive dick is inside him, your advance is halted.  Before you even think to complain his insides begin to squirm, shifting to make room for the rest of your [cock " + x1 + "].  You reach down and grab his hips, pulling him back until his plump muscled cheeks softly mash against your trunk.  He howls as you maintain a firm grip on his slender hips, not allowing him to move an inch.  Through your fully embedded [cock " + x1 + "] you can feel his hole quivering as it pumps massive gobs of that creamy, slick lube in an attempt to make the fuck easier.  A yank on the collar causes the demon to begin slowly forcing himself up and down the length of your [cock " + x1 + "].  After a few incursions Akbal picks up the pace and becomes lost in fucking himself up and down your giant pole.  His natural lube even slides out and drips down your [legs] as he repeatedly smashes his insatiable ass into you.  Unbidden, a groan finds its way out your mouth as the demon works you over, having gone from neophyte to pro in a matter of minutes.");
+				doNext(curry(dickF2, x));
 			}
-			outputText("\n\nThe bound demon’s legs stretch straight out, his barbed dick flexing in anticipation.  You touch it, feeling the wetness of the self-lubing demon dick cling to your fingers as you feel one of the barbs.  It is spongy, soft but not too soft.  The demon hisses as you tease him, your fingers sliding across the rubbery barbs that cover his rock-hard sex organ.  When you begin to lower yourself onto his shuddering dick, the demon begins to purr.");
-
-			menu();
-			addButton(0, "Next", topAkbitchFromBottomDuex);
-		}
-
-		private function topAkbitchFromBottomDuex():void
-		{
-			clearOutput();
-			outputText(images.showImage("akbal-deepwoods-male-akbalonback2"));
-			//-page turn-
-			//{tight/virgin vag/ass}
-			if ((!player.hasVagina() && player.ass.analLooseness < 2) || (player.hasVagina() && player.looseness() <= 2))
-				outputText("As you begin to impale yourself on the demonic pole, you gasp as your [vagOrAss] is spread wide by Akbal’s rather large demon-cat dick.  The remnants of his spit on your [vagOrAss] reacts to the mystic lube and any pain you would have felt is gone, replaced by mind numbing bliss.  The demon begins to thrust up into your [vagOrAss], which you cannot help but allow.  The sensation is beyond ecstasy - it is pure euphoria, exploding like a firecracker and blasting through you like a wave.  All too soon the pleasure peaks.");
-			//{medium vag/ass}
-			else if ((!player.hasVagina() && player.ass.analLooseness < 4) || (player.hasVagina() && player.looseness() < 4))
-				outputText("As you impale yourself on the demon’s quivering dick, a moan finds itself coming out of your mouth.  The moment the remnants of saliva in your [vagOrAss] touch the lube coating his barbed cock, you see stars.  Lost in the moment, you cannot believe anything can feel this good.  You ride up and down the entire length of the demon’s damned sex organ.  It’s almost as if you’re bouncing up and down on a rod of pure bliss, like your entire being is being impaled by pure joy.  All too soon the pleasure peaks.");
-			//{gapped pussy}
-			else
-				outputText("As you slide down the demon’s quivering dick your eyes roll back.  As the demonic saliva coating your [vagOrAss] comes into contact with the lube on his barbed, demon-cat dick, you cannot believe anything can feel this good.  Suddenly, you are bouncing as hard as you can while the demon thrusts up into you.  Your bodies slam together causing a thunderous applause to ring out across the clearing as you ride him as hard as you can.  The combination of the size and thickness of his ribbed, textured dick combined with the chemical stimulants makes your entire being cry out.  You feel as if you are drowning in ecstasy, as if an unending paradise is blooming inside you from your [vagOrAss].  All too soon the pleasure peaks.");
-			if (player.hasVagina())
-				player.cuntChange(16, true, true, false);
-			else
-				player.buttChange(16, true, true, false);
-
-			//[if (hasCock = true)]
-			if (player.hasCock())
-			{
-				outputText("\n\nYou wrap your hand around [oneCock] as it swells.  Every nerve ending in your body explodes as ");
-				if (player.hasVagina())
-					outputText("both ");
-				outputText("your sex organ");
-				if (player.hasVagina())
-					outputText("s climax at once");
+			function dickF2(x:int):void {
+				var x1:int = x + 1;
+				clearOutput();
+				outputText(images.showImage("akbal-deepwoods-male-buttfuck2"));
+				outputText("Without warning, Akbal’s insides become vacuum tight.  Convulsions rocket through his body, and you realize he has reached his climax without any attention to his barbed dick.  ");
+				if (player.cor < 90)
+					outputText("You hold the demon’s make-shift collar, letting him ride out his orgasm as he cries out in pure ecstasy, reveling in the satisfaction of knowing you have made him your bitch.");
 				else
-					outputText(" climaxes");
-				outputText(".  Your [vagOrAss] spasms around the demon’s embedded cock as [eachCock] paints his chest and face with a generous coating of baby batter.  Your orgasm rages on, covering the demon cat in your sex fluids, matting his fur and darkening it with more seed than you ever thought possible.");
-			}
-			//[if (hasCock = false)
-			else
-				outputText("\n\nEvery nerve ending in your body explodes as you convulse atop the jaguar.  With a hoarse groan, your [vagOrAss] begins to spasm around the embedded pleasure rod as it gushes more fluid than you thought possible.  Soon the Jaguar is soaked from waist to thigh.");
+					outputText("You pound your bitch’s quivering rectum, reveling in the pulsating pressure as Akbal roars beneath you, a sound of mixed pain and ecstasy as you decimate his clenching hole with brutal thrusts.");
 
-			outputText("\n\nYou look back at your new bitch with a grin while he regains his senses.  As you leave the forest, you hear a promise from Akbal’s chorus of voices, \"<i>You will regret this... Champion.</i>\"");
-			player.sexReward("cum", "Vaginal");
-			dynStats("cor", 3);
-			if (player.hasVagina() && !player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
-			doNext(camp.returnToCampUseOneHour);
+				outputText("\n\nSoon you feel that familiar pressure building. Bearing down on him, you begin to slam into his thrusts and enjoy the demon’s snarling, his tail curling every time your two bodies meet with a loud clap.");
+
+				//{if player has horse cock}
+				if (player.cocks[x].cockType == CockTypesEnum.HORSE)
+					outputText("\n\nAs your shaft splits Akbal in two, he somehow can’t even begin to keep up with the renewed viciousness of your pounding [cock " + x1 + "].  One deep, soul shattering thrust causes Akbal to spit fire as you yank his collar and hold, pouring baby batter into his bowels until it spills from the brutally stretched hole, around your [cock " + x1 + "] in streams of thick white goo.");
+				//{if player has tentacle dick}
+				else if (player.cocks[x].cockType == CockTypesEnum.TENTACLE)
+					outputText("\n\nSuddenly your [cock " + x1 + "] goes wild.  Akbal is howling as his bowels are rearranged by your [cock " + x1 + "].  Looking down you can see your [cock " + x1 + "] moving around beneath his skin and fur.  When the first spurts of your orgasm begin to fire into his dancing bowels, Akbal pushes back, smashing himself into you as he is hit by a second orgasm thanks to your [cock " + x1 + "] agitating his very swollen and very abused prostate.");
+				//{if player has cat dick}
+				else if (player.cocks[x].cockType == CockTypesEnum.CAT)
+					outputText("\n\nAkbal seems particularly fond of your [cock " + x1 + "] as he dances on its rigid length.  When your embedded [cock " + x1 + "] begins to spurt hot seed into the demon’s bowels you take control and start mercilessly slamming your [hips] into the jaguar's upturned back side.  He shivers as you beat out a titanic orgasm.  Even after you are spent, he continues to grind against your [cock " + x1 + "].");
+				//{if player has knot}
+				else if (player.hasKnot(x))
+					outputText("\n\nYou meet your new bitch’s ass with a clap of your hips, sawing your [cock " + x1 + "] in and out of his gloriously tight hole.  He howls as you force your swollen knot into his back door with an audible pop.  He reacts by falling flat against the ground in an attempt to get away from the sudden extra girth invading his tailhole, pulling you with him. With your arms wrapped around his you howl and grind your exploding [cock " + x1 + "] into his corked bowels, filling the demon body full of hot seed, causing his stomach to swell slightly.");
+				//{if player has human/kanga dick}
+				else
+					outputText("\n\nYou pull on the collar and fall forward.  You begin to blast hot seed into Akbal’s shivering bowels while continuing to pound him into submission, the collar clenched in your fist as you beat out your orgasm, streams of baby batter running down the bitch’s legs and scrotum.");
+
+				outputText("\n\nYou look back at your new bitch with a grin while he regains his senses.  As you leave the forest you hear a promise from Akbal’s chorus of voices, \"<i>You will regret this... Champion.</i>\"");
+
+				player.sexReward("Default", "Dick", true, false);
+				dynStats("cor", 3);
+				doNext(camp.returnToCampUseOneHour);
+			}
+
+			function vagF():void {
+				outputText(images.showImage("akbal-deepwoods-male-akbalonback"));
+				//[{if goo legs}]
+				if (player.isGoo())
+					outputText("You lay down in the soft grass with a mischievous grin.  Using the collar, you yank Akbal forward, causing his mouth to splash into your [vagOrAss].  Instantly your entire form feels as if waves of pure ecstasy are cascading through you.  The feeling peaks and recedes in an unpredictable pattern, and you’re lost in the feel of the demon’s mystic saliva as you ride out your orgasm, reveling in the heat of his tongue coated in that wonderful spit.  When you can stand it no more, you push the demon onto his back and look upon his rigid tool as it leaks and quivers while pointing to the sky.");
+				//[if (biped = true)
+				else {
+					sceneHunter.print("Failed check: goo body.");
+					outputText("You lay down in the soft grass with the collar in hand.  You wrap your arms around your [legs], holding them up to give the demon an easier target.  With a light tug the demon takes the hint and smashes his face into your [vagOrAss].  The sensations coursing through your body as his tongue flitters across your ");
+					if (player.hasVagina())
+						outputText("clit");
+					else
+						outputText("prostate");
+					outputText(" makes you cringe.  Your new toy laps at your [vagOrAss] and sends shivers coursing through your body as your [vagina] becomes drenched.  Something about his saliva causes an almost electric sensation to shoot through you. When you can stand it no more, you push the demon onto his back and look upon his rigid tool as it quivers.");
+				}
+				outputText("\n\nThe bound demon’s legs stretch straight out, his barbed dick flexing in anticipation.  You touch it, feeling the wetness of the self-lubing demon dick cling to your fingers as you feel one of the barbs.  It is spongy, soft but not too soft.  The demon hisses as you tease him, your fingers sliding across the rubbery barbs that cover his rock-hard sex organ.  When you begin to lower yourself onto his shuddering dick, the demon begins to purr.");
+				doNext(vagF2);
+			}
+			function vagF2():void {
+				clearOutput();
+				outputText(images.showImage("akbal-deepwoods-male-akbalonback2"));
+				//-page turn-
+				//{tight/virgin vag/ass}
+				if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_LOOSE || (player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_LOOSE))
+					outputText("As you begin to impale yourself on the demonic pole, you gasp as your [vagOrAss] is spread wide by Akbal’s rather large demon-cat dick.  The remnants of his spit on your [vagOrAss] reacts to the mystic lube and any pain you would have felt is gone, replaced by mind-numbing bliss.  The demon begins to thrust up into your [vagOrAss], which you cannot help but allow.  The sensation is beyond ecstasy - it is pure euphoria, exploding like a firecracker and blasting through you like a wave.  All too soon the pleasure peaks.");
+				//{medium vag/ass}
+				else if ((!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_GAPING) || (player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_GAPING))
+					outputText("As you impale yourself on the demon’s quivering dick, a moan finds itself coming out of your mouth.  The moment the remnants of saliva in your [vagOrAss] touch the lube coating his barbed cock, you see stars.  Lost in the moment, you cannot believe anything can feel this good.  You ride up and down the entire length of the demon’s damned sex organ.  It’s almost as if you’re bouncing up and down on a rod of pure bliss, like your entire being is being impaled by pure joy.  All too soon the pleasure peaks.");
+				//{gapped pussy}
+				else
+					outputText("As you slide down the demon’s quivering dick, your eyes roll back.  As the demonic saliva coating your [vagOrAss] comes into contact with the lube on his barbed, demon-cat dick, you cannot believe anything can feel this good.  Suddenly, you are bouncing as hard as you can while the demon thrusts up into you.  Your bodies slam together causing a thunderous applause to ring out across the clearing as you ride him as hard as you can.  The combination of the size and thickness of his ribbed, textured dick combined with the chemical stimulants makes your entire being cry out.  You feel as if you are drowning in ecstasy, as if an unending paradise is blooming inside you from your [vagOrAss].  All too soon the pleasure peaks.");
+				if (player.hasVagina())
+					player.cuntChange(16, true, true, false);
+				else
+					player.buttChange(16, true, true, false);
+
+				//[if (hasCock = true)]
+				if (player.hasCock()) {
+					outputText("\n\nYou wrap your hand around [oneCock] as it swells.  Every nerve ending in your body explodes as ");
+					if (player.hasVagina())
+						outputText("both ");
+					outputText("your sex organ");
+					if (player.hasVagina())
+						outputText("s climax at once");
+					else
+						outputText(" climaxes");
+					outputText(".  Your [vagOrAss] spasms around the demon’s embedded cock as [eachCock] paints his chest and face with a generous coating of baby batter.  Your orgasm rages on, covering the demon cat in your sex fluids, matting his fur and darkening it with more seed than you ever thought possible.");
+				}
+				//[if (hasCock = false)
+				else
+					outputText("\n\nEvery nerve ending in your body explodes as you convulse atop the jaguar.  With a hoarse groan, your [vagOrAss] begins to spasm around the embedded pleasure rod as it gushes more fluid than you thought possible.  Soon the Jaguar is soaked from waist to thigh.");
+
+				outputText("\n\nYou look back at your new bitch with a grin while he regains his senses.  As you leave the forest, you hear a promise from Akbal’s chorus of voices, \"<i>You will regret this... Champion.</i>\"");
+				player.sexReward("cum", "Vaginal");
+				dynStats("cor", 3);
+				if (player.hasVagina() && !player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
+				doNext(camp.returnToCampUseOneHour);
+			}
 		}
 
-		//AMB Strength Scene
-		//70+
-		private function akbitchHighStrengthVariant():void
-		{
+		private function akbitchStrength():void {
 			clearOutput();
 			outputText("With a wicked grin, you rip off your [armor] and grab the bound demon by the scruff on his neck.  He does this sexy little wiggle as you hoist him until he reaches eye level, easily manipulating his light weight as you inspect his slim, toned body.  His chest heaves, his nipples stand at attention, and his erect demon-cat dick drools a heavy river of thick cream, darkening the fur on his sack and inner thighs.  This is going to be fun.");
-			if (player.hasCock())
-			{
+			sceneHunter.passCheckOnce();
+			sceneHunter.selectGender(
+				curry(sceneHunter.callBigSmall, dickF, 12, 7, "length", 20), vagF, null, null, 1,
+				player.cockThatFits(20, "length") >= 0, "Too big! (Req. a dick shorter than 20 inches)");
+
+			//====================================================================================
+			function dickF(x:int):void {
+				var x1:int = x + 1;
 				outputText(images.showImage("akbal-deepwoods-male-highstrength"));
-				//if (hasCock = true)
-				outputText("\n\nAkbal licks your [face], quite obviously lost in lust.  You can’t help but chuckle because this self proclaimed god has turned into your submissive little bitch.  You pin him to a nearby tree and slide your hands down his lust crazed body to his slim waist.  You then grab your [cock] and push it up into the demon’s soft cleft.");
-				var x:int = player.biggestCockIndex();
+				outputText("\n\nAkbal licks your [face], quite obviously lost in lust.  You can’t help but chuckle because this self-proclaimed god has turned into your submissive little bitch.  You pin him to a nearby tree and slide your hands down his lust crazed body to his slim waist.  You then grab your [cock] and push it up into the demon’s soft cleft.");
 				//{If CockLength < 7}
 				if (player.cocks[x].cockLength < 7)
-					outputText("\n\nAkbal purrs as you shove your [cockHead biggest] into his hot, dripping hole.  The all-natural lube oozing from his anal walls helps you smoothly glide through the tight ring.  In a show of strength, you pull the demon away from the tree, supporting his full weight as you begin to lift him up and down the full length of your [cock biggest].  Akbal purrs as you slam his entire body into your thrusting [cock biggest] with reckless abandon.  His pleasure is made more obvious by the gigantic barbed dick sliding against your [fullChest] as the tightness of his hot, wet tailhole makes you groan.");
+					outputText("\n\nAkbal purrs as you shove your [cock " + x1 + "] into his hot, dripping hole.  The all-natural lube oozing from his anal walls helps you smoothly glide through the tight ring.  In a show of strength, you pull the demon away from the tree, supporting his full weight as you begin to lift him up and down the full length of your [cock " + x1 + "].  Akbal purrs as you slam his entire body into your thrusting [cock " + x1 + "] with reckless abandon.  His pleasure is made more obvious by the gigantic barbed dick sliding against your [fullChest] as the tightness of his hot, wet tailhole makes you groan.");
 				//{if CockLength is between 7 and 12}
 				else if (player.cocks[x].cockLength < 12)
-					outputText("\n\nAkbal groans as you shove your [cockHead biggest] into his hot, dripping tailhole.  The lube oozing out of his anal walls allows you to slide your full [cock biggest] into the slick chute with little effort, and you spy the demon’s toes wiggling out the corner of your eyes.  Showing off your muscles, you lift the demon’s entire body up until only the tip of your [cock biggest] remains embedded inside his tight opening.  Without warning you thrust forward while slamming him down, ramming your entire [cock biggest] into him as hard as you can.  He flinches and roars.  As you continue to pound his tightly clinging insides while supporting his full weight, his demon-cat dick repeatedly slides against your [fullChest], leaking a steady stream of pre-jizz down your body.  His slim weight is easy to manipulate.  His hole squeezes in time with your thrusts, massaging your embedded [cock] and spurring you to slam up into his quivering hole even harder.");
+					outputText("\n\nAkbal groans as you shove your [cock " + x1 + "] into his hot, dripping tailhole.  The lube oozing out of his anal walls allows you to slide your full [cock " + x1 + "] into the slick chute with little effort, and you spy the demon’s toes wiggling out the corner of your eyes.  Showing off your muscles, you lift the demon’s entire body up until only the tip of your [cock " + x1 + "] remains embedded inside his tight opening.  Without warning you thrust forward while slamming him down, ramming your entire [cock " + x1 + "] into him as hard as you can.  He flinches and roars.  As you continue to pound his tightly clinging insides while supporting his full weight, his demon-cat dick repeatedly slides against your [fullChest], leaking a steady stream of pre-jizz down your body.  His slim weight is easy to manipulate.  His hole squeezes in time with your thrusts, massaging your embedded [cock] and spurring you to slam up into his quivering hole even harder.");
 				//{if CockLength > 12}
 				else
-					outputText("\n\nAkbal roars as your [cockHead biggest] is shoved into his tight, dripping tailhole.  The all natural lube does little to help you punch your way into his colon.  He squirms in your arms, trying to get away from the sudden pressure of your forcefully invading [cock biggest].  You laugh as you pull his body down while pushing up into his dripping tailhole.  After about a foot of your [cock biggest] forces its way in his hot innards, you are halted.  You begin to feel a rumbling that tickles the embedded portion of your [cock biggest].  You realize Akbal’s insides have begun to shift, making room for your [cock biggest].  The bound demon flinches and growls as you push his slender body down your [cock biggest] until his ass has engulfed your entire length.  The demon shudders as his barbed tool explodes, painting your [fullChest] and [face] with long ropes of sweet, creamy cat-jizz.  Flexing your muscles, you pull his back off the tree and begin to lift Akbal up and down the entire length of your [cock biggest].  Despite his earlier orgasm, Akbal’s barbed dick is still rock hard against your [fullChest] and leaking a heavy river of creamy white down your already soiled front.  You grin as the eyes of this 'god' of the terrestrial fire roll up into his head as you slam him down, splitting the willing bitch open with your [cock biggest].");
-				outputText("\n\nSuddenly Akbal’s body goes into convulsions, and you know if his hands were free he’d be clawing at your back.  His legs lock around your waist as a jet of white hot cream hits the bottom of your face, quickly followed by another and another, causing his hole to quiver around your embedded shaft as the demon unloads ");
+					outputText("\n\nAkbal roars as your [cock " + x1 + "] is shoved into his tight, dripping tailhole.  The all natural lube does little to help you punch your way into his colon.  He squirms in your arms, trying to get away from the sudden pressure of your forcefully invading [cock " + x1 + "].  You laugh as you pull his body down while pushing up into his dripping tailhole.  After about a foot of your [cock " + x1 + "] forces its way in his hot innards, you are halted.  You begin to feel a rumbling that tickles the embedded portion of your [cock " + x1 + "].  You realize Akbal’s insides have begun to shift, making room for your [cock " + x1 + "].  The bound demon flinches and growls as you push his slender body down your [cock " + x1 + "] until his ass has engulfed your entire length.  The demon shudders as his barbed tool explodes, painting your [fullChest] and [face] with long ropes of sweet, creamy cat-jizz.  Flexing your muscles, you pull his back off the tree and begin to lift Akbal up and down the entire length of your [cock " + x1 + "].  Despite his earlier orgasm, Akbal’s barbed dick is still rock hard against your [fullChest] and leaking a heavy river of creamy white down your already soiled front.  You grin as the eyes of this 'god' of the terrestrial fire roll up into his head as you slam him down, splitting the willing bitch open with your [cock " + x1 + "].");
+				outputText("\n\nSuddenly Akbal’s body goes into convulsions, and you know if his hands were free he’d be clawing at your back.  His legs lock around your waist as a jet of white cream hits the bottom of your face, quickly followed by another and another, causing his hole to quiver around your embedded shaft as the demon unloads ");
 				if (player.cocks[x].cockLength > 12)
 					outputText("another");
 				else
@@ -1469,36 +1281,35 @@ public class AkbalScene extends BaseContent
 				outputText(" titanic orgasm onto your [fullChest].");
 
 				//{corruption < 90}
-				if (player.cor < 90)
-				{
+				if (player.cor < 90) {
 					outputText("\n\nYou can’t help but smile as evidence of the demon’s pleasure continues to spurt, leaving everything below your chin soaked in demon spunk and letting you know that he truly is your little bitch.");
 				}
 				//{corruption > 90}
 				else
 					outputText("\n\nYou flex your muscles as you wrap your arms around Akbal’s slim waist, bending down slightly to get a better angle.  You begin to pump into the demon’s quivering hole, abusing the convulsing sheath with brutal thrusts.  The demon’s voice breaks with each soul shattering thrust as his demon-cat dick unloads, leaving you covered from the chin down in a hot, creamy mess.");
-				outputText("\n\nAkbal shudders as his orgasm ends.  With your [cock biggest] still embedded, the two of you fall to the forest floor.  You pry his legs from your waist and crush them into his jism soaked chest.  With a snarl you slam your [cock biggest] into him with all your strength as you feel [eachCock] begin to tremble.  Every full length slam of your [cock biggest] forces a yelp out of the demon’s throat.  Soon you feel a familiar pressure building in your groin as you pound Akbal into the ground.");
+				outputText("\n\nAkbal shudders as his orgasm ends.  With your [cock " + x1 + "] still embedded, the two of you fall to the forest floor.  You pry his legs from your waist and crush them into his jism soaked chest.  With a snarl you slam your [cock " + x1 + "] into him with all your strength as you feel [eachCock] begin to tremble.  Every full length slam of your [cock " + x1 + "] forces a yelp out of the demon’s throat.  Soon you feel a familiar pressure building in your groin as you pound Akbal into the ground.");
 
-				//{if player has dog cock + knot}
-				if (player.hasKnot(x))
-					outputText("\n\nWith all your strength, you slam your [cock biggest] down into the bitch’s abused tailhole, forcing your swollen knot in with an audible pop.  the demon growls as you cork his anal ring, ensuring your seed won’t escape his hot little hole.  With a rumbling howl, you unload into the demon’s corked bowels, your seed pouring into the hot tube until your [cockHead biggest] is swimming in your own baby batter and Akbal’s stomach is slightly swollen.");
 				//{if player has horse dick}
-				else if (player.cocks[x].cockType == CockTypesEnum.HORSE)
-					outputText("\n\nYour thrusts double in force as you throw your head back and ram into the little bitch with all your strength.  Deep inside his rearranged bowls, your [cock biggest] expels a tidal wave of dick snot into Akbal’s quivering insides.  You and the demon cry out together as your [cock biggest] twitches inside him, breeding him with fresh baby batter as you grind your [cock biggest] around in his little bitch hole.");
+				if (player.cocks[x].cockType == CockTypesEnum.HORSE)
+					outputText("\n\nYour thrusts double in force as you throw your head back and ram into the little bitch with all your strength.  Deep inside his rearranged bowls, your [cock " + x1 + "] expels a tidal wave of dick snot into Akbal’s quivering insides.  You and the demon cry out together as your [cock " + x1 + "] twitches inside him, breeding him with fresh baby batter as you grind your [cock " + x1 + "] around in his little bitch hole.");
 				//{if player has tentacle dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.TENTACLE)
-					outputText("\n\nWhen you feel the pressure of your impending orgasm building, you slam your [cock biggest] in to the hilt.  Inside Akbal’s bowels your [cock biggest] goes crazy.  You have to redouble your efforts to hold his thighs to his cum stained chest as he struggles while your [cock biggest] twists and turns inside his overstimulated ass.  When your deeply embedded [cock biggest] begins to spill your seed, you can’t help but grind your [cock biggest] into Akbal’s wrecked bowels as the demon goes limp, too tired to fight the intense sensations your [cock biggest] causes him.");
+					outputText("\n\nWhen you feel the pressure of your impending orgasm building, you slam your [cock " + x1 + "] in to the hilt.  Inside Akbal’s bowels your [cock " + x1 + "] goes crazy.  You have to redouble your efforts to hold his thighs to his cum stained chest as he struggles while your [cock " + x1 + "] twists and turns inside his overstimulated ass.  When your deeply embedded [cock " + x1 + "] begins to spill your seed, you can’t help but grind your [cock " + x1 + "] into Akbal’s wrecked bowels as the demon goes limp, too tired to fight the intense sensations your [cock " + x1 + "] causes him.");
 				//{if player has cat dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.CAT)
-					outputText("\n\nAs you slam your [cock biggest] in to the hilt, Akbal wraps his legs around your waist, obviously very fond of your [cock biggest].  With your [fullChest] against his jizz-soaked chest, your [cock biggest] begins to blast his innards with hot cum.  As your orgasm rages on, you grind your [cock biggest] around in the demon’s massaging hole.");
+					outputText("\n\nAs you slam your [cock " + x1 + "] in to the hilt, Akbal wraps his legs around your waist, obviously very fond of your [cock " + x1 + "].  With your [fullChest] against his jizz-soaked chest, your [cock " + x1 + "] begins to blast his innards with hot cum.  As your orgasm rages on, you grind your [cock " + x1 + "] around in the demon’s massaging hole.");
 				//{if player has dragon dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.DRAGON)
-					outputText("\n\nAs you slam the full length of your [cock biggest] into Akbal’s upturned ass, he flinches as the bulb at the base of your shaft is shoved into him.  This matters very little to you as your [cockHead biggest] begins to blast torrents of hot seed into his quivering bowels.  The demon squirms as you grind your [cock biggest] into his hole as a river of white cream spills from the abused hole and slides down his body to the forest floor.");
+					outputText("\n\nAs you slam the full length of your [cock " + x1 + "] into Akbal’s upturned ass, he flinches as the bulb at the base of your shaft is shoved into him.  This matters very little to you as your [cock " + x1 + "] begins to blast torrents of hot seed into his quivering bowels.  The demon squirms as you grind your [cock " + x1 + "] into his hole as a river of white cream spills from the abused hole and slides down his body to the forest floor.");
 				//{If player has Lizard dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.LIZARD)
-					outputText("\n\nAs you smash your [hips] into Akbal’s upturned ass, he suddenly clenches.  Relishing in the bumpy texture, the demon groans as your embedded [cock biggest] explodes and shoots hot cream into his stuffed bowels.  As your body convulses with each twitch of your [cock biggest], the bitch’s hole begins to overflow, spilling from his abused hole in thick gobs.");
+					outputText("\n\nAs you smash your [hips] into Akbal’s upturned ass, he suddenly clenches.  Relishing in the bumpy texture, the demon groans as your embedded [cock " + x1 + "] explodes and shoots hot cream into his stuffed bowels.  As your body convulses with each twitch of your [cock " + x1 + "], the bitch’s hole begins to overflow, spilling from his abused hole in thick gobs.");
+				//{if player has  knot}
+				else if (player.hasKnot(x))
+					outputText("\n\nWith all your strength, you slam your [cock " + x1 + "] down into the bitch’s abused tailhole, forcing your swollen knot in with an audible pop.  the demon growls as you cork his anal ring, ensuring your seed won’t escape his hot little hole.  With a rumbling howl, you unload into the demon’s corked bowels, your seed pouring into the hot tube until your [cock " + x1 + "] is swimming in your own baby batter and Akbal’s stomach is slightly swollen.");
 				//{if player has human/kanga dick}
 				else
-					outputText("\n\nYou ram your [cock biggest] into his upturned ass with all your strength and hold, causing the demon to roar as you shoot globs of white-hot cream into his wrecked and abused hole.  Soon your seed is dribbling down his upturned ass cheeks and spilling onto the forest floor.");
+					outputText("\n\nYou ram your [cock " + x1 + "] into his upturned ass with all your strength and hold, causing the demon to roar as you shoot globs of white-hot cream into his wrecked and abused hole.  Soon your seed is dribbling down his upturned ass cheeks and spilling onto the forest floor.");
 
 				//{corruption < 90}
 				if (player.cor < 90)
@@ -1506,12 +1317,12 @@ public class AkbalScene extends BaseContent
 				//{corruption > 90}
 				else
 					outputText("\n\nYou stand and Akbal’s legs flop from where you had them pinned to his chest.  You gather your [armor] and dress before aiming a wicked slap at Akbal’s tender cheeks and leaving him tied up for the imps and goblins you spy watching the two of you from the trees.\n\nYou tell him he is all theirs and share a conspiratorial grin as you head back to camp.");
-				player.sexReward("Default","Dick",true,false);
+				player.sexReward("Default", "Dick", true, false);
 				dynStats("cor", 3);
 				doNext(camp.returnToCampUseOneHour);
 			}
-			else
-			{
+
+			function vagF():void {
 				outputText(images.showImage("akbal-deepwoods-female-highstrength"));
 				outputText("\n\nAkbal licks your [face], quite obviously lost in lust.  He’s lost all pretense of being some god and is now your own personal bitch.  With a wicked grin, you drop him ass first onto the ground.  You turn on your heel and squat until your [vagOrAss] is in his face, letting him get a good whiff.  Then you unceremoniously grab the fur on his head and jam him muzzle first into your [vagOrAss].");
 				outputText("\n\nAkbal begins tonguing your [vagOrAss] with the technique of a veteran.  As he slathers your ");
@@ -1529,35 +1340,33 @@ public class AkbalScene extends BaseContent
 				outputText("\n\nWithout warning, you shove the little bitch onto his back and press his legs to his chest.  His heavy sack is drawn up tight, his self-lubing cock still pumping a river of lubricant and pre.  Using your muscles, you trap him in this position with your legs before reaching behind you to grab his barbed cock.  The barbed appendage is rubbery and wet with slick fluid.  Touching it causes Akbal to try to thrust upward, but it's damn near impossible against someone as strong as you.  Aiming his slick, ribbed demon-cat dick into your [vagOrAss], you begin to ease down onto it.");
 
 				//{tight/virgin vagorass}
-				if ((!player.hasVagina() && player.ass.analLooseness < 2) || (player.hasVagina() && player.looseness() <= 2))
+				if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_LOOSE || player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_LOOSE)
 					outputText("\n\nAs soon as your [vagOrAss] begins to envelop the thick head of Akbal’s giant, barbed dick, you let out a loud moan.  As the remnants of the spit slathered across your [vagOrAss] mixes with the lube on Akbal’s swollen sex organ, your body flinches from the tidal wave of pleasure.  Even those gorgeous barbs feel as though they’re soft, vibrating beads, wiggling as you envelop the demonic cock.  Thanks to the mixture, you are able to take his full length and revel in the stretched feeling having all that man meat gives you.  Akbal attempts to move, to thrust up into your [vagOrAss], but you hold him here, asserting your dominance as you easily keep the bitch boy pinned.");
 				//{medium vagorAss}
-				if ((!player.hasVagina() && player.ass.analLooseness < 4) || (player.hasVagina() && player.looseness() < 4))
-					outputText("\n\nAs soon as your [vagOrAss] begins to envelop the thick head of Akbal’s giant, barbed dick, you let out a squeal of delight. As your saliva drenched [vagOrAss] comes into contact with the lube soaking his demon dick, you almost pass out from the immense pleasure the mixture causes.  Those wonderful barbs are even vibrating against your tender flesh.  The girthy prick inside you is pure heat and vibrating pleasure that has your body tingling from your [vagOrAss] to your [feet].  Akbal attempts to move, to thrust up into your [vagOrAss] but you hold him here, asserting your dominance as you easily keep the bitch boy pinned.");
+				if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_GAPING || player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_GAPING)
+					outputText("\n\nAs soon as your [vagOrAss] begins to envelop the thick head of Akbal’s giant, barbed dick, you let out a squeal of delight. As your saliva drenched [vagOrAss] comes into contact with the lube soaking his demon dick, you almost pass out from the immense pleasure the mixture causes.  Those wonderful barbs are even vibrating against your tender flesh.  The girthy prick inside you is pure heat and vibrating pleasure that has your body tingling from your [vagOrAss] to your [feet].  Akbal attempts to move, to thrust up into your [vagOrAss], but you hold him here, asserting your dominance as you easily keep the bitch boy pinned.");
 				//{Gaped vagorAss}
 				else
-					outputText("\n\nAs soon as that giant erection touches your [vagOrAss], your face twists into a sexy grimace of pure euphoria.  The spit-drenched opening of your [vagOrAss] coming into contact with his lube soaked sex organ causes you to see stars.  Add to that the way the barbs inside seem to vibrate, and you are in heaven.  You slide down Akbal’s length without a problem.  Akbal attempts to move, to thrust up into your [vagOrAss] but you hold him here, asserting your dominance as you easily keep the bitch-boy pinned.");
+					outputText("\n\nAs soon as that giant erection touches your [vagOrAss], your face twists into a sexy grimace of pure euphoria.  The spit-drenched opening of your [vagOrAss] coming into contact with his lube soaked sex organ causes you to see stars.  Add to that the way the barbs inside seem to vibrate, and you are in heaven.  You slide down Akbal’s length without a problem.  Akbal attempts to move, to thrust up into your [vagOrAss], but you hold him here, asserting your dominance as you easily keep the bitch-boy pinned.");
 
 				if (player.hasVagina())
 					player.cuntChange(16, true, true, false);
 				else
 					player.buttChange(16, true, true, false);
 
-				outputText("\n\nYou place your hands on Akbal’s muscular calves and push down, causing the demon’s cock to tremble within you.  With your legs positioned outside of his, you squeeze his legs together and begin to rock back and forth.  As you slowly slide up and down the rigid length of Akbal’s pleasure rod, he goes crazy.  You can feel his muscles straining against your vice like grip as you tortuously slide up and down his length as slow as you can, willing yourself to not go wild as you silently assert your dominance over your bitch.  After a while you begin to speed up, slowly increasing tempo as you glide across his rock hard demon dick.");
+				outputText("\n\nYou place your hands on Akbal’s muscular calves and push down, causing the demon’s cock to tremble within you.  With your legs positioned outside of his, you squeeze his legs together and begin to rock back and forth.  As you slowly slide up and down the rigid length of Akbal’s pleasure rod, he goes crazy.  You can feel his muscles straining against your vice-like grip as you tortuously slide up and down his length as slow as you can, willing yourself to not go wild as you silently assert your dominance over your bitch.  After a while you begin to speed up, slowly increasing tempo as you glide across his rock hard demon dick.");
 
 				outputText("\n\nSoon you feel Akbal’s embedded dick begin to jump, and every sensation is intensified as his hot cream shoots into your now rapidly riding [vagOrAss].  The sensations are too much.");
 
 				//[if (hasVagina = true)
-				if (player.hasVagina())
-				{
+				if (player.hasVagina()) {
 					outputText("\n\nYour [vagina] explodes, causing your body to jerk and twist as you rapidly pump out your orgasm.");
 					player.sexReward("cum", "Vaginal");
 				}
 				else
-					outputText("\n\nYour body begins to convulse and you feel as though lightning bolts of pure elation are shooting through your soul.");
+					outputText("\n\nYour body begins to convulse, and you feel as though lightning bolts of pure elation are shooting through your soul.");
 				//[if (hasCock = true) \"<i>
-				if (player.hasCock())
-				{
+				if (player.hasCock()) {
 					outputText("  [EachCock] swells and explodes, shooting cream all over Akbal’s thighs, chest and face as you unload thick white rope after rope.");
 					player.sexReward("Default", "Dick", true, false);
 				}
@@ -1570,51 +1379,51 @@ public class AkbalScene extends BaseContent
 
 		//AMB Speed Scene
 		//70
-		private function akbalBitchSpeed():void
-		{
+		private function akbitchSpeed():void {
 			clearOutput();
 			outputText("Akbal groans as he lies face first in the dirt.  His body has already morphed into a more humanoid form.  You smile as you watch him hump the grass, two hollows forming in his ass cheeks as they clench and unclench.  The sight of him futilely trying to stimulate himself gets you so hot you practically rip off your [armor] and grab the tied up demon with a grin.");
 			outputText("\n\n\"<i>[Master],</i>\" Akbal’s chorus of voices croons in your mind.");
+			sceneHunter.passCheckOnce();
+			sceneHunter.selectGender(
+				curry(sceneHunter.callBigSmall, dickF, 12, 7, "length", 20), vagF, null, null, 1,
+				player.cockThatFits(20, "length") >= 0, "Too big! (Req. a dick shorter than 20 inches)");
 
-			var x:int = player.biggestCockIndex();
-
-			//[if (hasCock = true)]
-			if (player.hasCock())
-			{
+			//====================================================================================
+			function dickF(x:int):void {
+				var x1:int = x + 1;
 				outputText(images.showImage("akbal-deepwoods-male-highspeed"));
-				outputText("\n\nYou pull his tail until the bound demon jaguar is face down, ass up.  His muscular cheeks part themselves thanks to previous incursions.  His soft pink hole shines with the natural lube he creates.  He lifts his spotted tail and spreads his legs, letting you know he’s ready.  You plant your [feet] and lean over his body. With your [cock biggest] in hand, you position your [cockHead biggest] at his rear entrance.  With your free hand, you aim a slap at the demon’s waiting rump, watching the furry, round cheeks jiggle as a dollop of lube drips out of the waiting hole.  Needing no further invitation you begin to push into the demon.");
+				outputText("\n\nYou pull his tail until the bound demon jaguar is face down, ass up.  His muscular cheeks part themselves thanks to previous incursions.  His soft pink hole shines with the natural lube he creates.  He lifts his spotted tail and spreads his legs, letting you know he’s ready.  You plant your [feet] and lean over his body. With your [cock " + x1 + "] in hand, you position your [cock " + x1 + "] at his rear entrance.  With your free hand, you aim a slap at the demon’s waiting rump, watching the furry, round cheeks jiggle as a dollop of lube drips out of the waiting hole.  Needing no further invitation you begin to push into the demon.");
 
 				//{cockLength < 7}
-				if (player.cocks[x].cockLength < 7)
-				{
-					outputText("\n\nWith your hands at his waist to provide the necessary balance, you begin to jackhammer his insides.  A constant, almost unending slurping fills the air as you repeatedly thrust your [cock biggest] into the demon’s upturned hole.  His ass jiggles with each thrust, and before it's done, another undulation rocks the furred surface.");
+				if (player.cocks[x].cockLength < 7) {
+					outputText("\n\nWith your hands at his waist to provide the necessary balance, you begin to jackhammer his insides.  A constant, almost unending slurping fills the air as you repeatedly thrust your [cock " + x1 + "] into the demon’s upturned hole.  His ass jiggles with each thrust, and before it's done, another undulation rocks the furred surface.");
 					//[if (hasBalls = false)
 					if (player.balls == 0)
-						outputText("  Your [cock biggest] drips gobs of his slick lube down the lower half of your body.");
+						outputText("  Your [cock " + x1 + "] drips gobs of his slick lube down the lower half of your body.");
 					else
-						outputText("  Your [cock biggest] drips gobs of his slick lube down your [sack] and the insides of your legs.");
+						outputText("  Your [cock " + x1 + "] drips gobs of his slick lube down your [sack] and the insides of your legs.");
 					outputText("  With clenched teeth you spur yourself to fuck the demon even faster, reaching your top speed.");
 				}
 				//{cockLength between 7 and 12}
-				else if (player.cocks[x].cockLength < 12)
-				{
-					outputText("\n\nAkbal pushes back against you, wiggling his round muscular ass against your trunk as his tail slides up against your [fullChest].  Planting your [feet], you sink inch by inch into the demon’s hot hole.  With your hands at his waist to provide the necessary balance, you begin to jackhammer his insides, causing the demon to growl up at you.  Reaching forward, you push down on the demon’s bound wrists, using them to force him to raise his ass up and give you an easier target.  The slurping caused by your [cock biggest] stabbing into the hot and quivering passage fills the air.   You smash into the furry, jiggling mounds of muscled ass on the demon below you.  The natural lube floods out of Akbal’s stuffed tailhole, painting your [cock biggest] with its creamy heat.  Endowed by your own lust, you begin to piston in and out of the demon’s hole like a madman.");
+				else if (player.cocks[x].cockLength < 12) {
+					outputText("\n\nAkbal pushes back against you, wiggling his round muscular ass against your trunk as his tail slides up against your [fullChest].  Planting your [feet], you sink inch by inch into the demon’s hot hole.  With your hands at his waist to provide the necessary balance, you begin to jackhammer his insides, causing the demon to growl up at you.  Reaching forward, you push down on the demon’s bound wrists, using them to force him to raise his ass up and give you an easier target.  The slurping caused by your [cock " + x1 + "] stabbing into the hot and quivering passage fills the air.   You smash into the furry, jiggling mounds of muscled ass on the demon below you.  The natural lube floods out of Akbal’s stuffed tailhole, painting your [cock " + x1 + "] with its creamy heat.  Endowed by your own lust, you begin to piston in and out of the demon’s hole like a madman.");
 				}
 				//{cockLength > 12}
-				else
-				{
-					outputText("\n\nYou are surprised you can even fit inside the demon’s tailhole.  The flesh wrapped around your [cock biggest] strains as you are halted by Akbal’s body.  You’re only able to fit a foot of your [cock biggest] into the demon, but you can feel his insides shifting.  The demon, stuffed beyond capacity, is somehow making room for the rest of your [cock biggest], and both of you can feel it.  The wriggling dickhole wrapped around your [cock biggest] is hot bliss, sliding, squeezing, and massaging your slowly advancing [cock biggest].  Beneath you, Akbal cringes and softly growls through clenched teeth as you sink, inch by inch, into his shifting innards.  When your trunk softly meshes against the demon’s upturned cheeks, a spasm rocks his body.  His insides tighten until you can’t move and Akbal shudders out a heavy orgasm.  You feel every spasm, every muscle contraction and every convulsion as the demon’s splatters his knees with rope after rope of creamy cat jizz.  Once Akbal’s hole relaxes again, you plant your [feet] and lean over his body with a mischievous grin.  With your hands at his waist to provide the necessary balance, you begin to jackhammer his insides, causing the demon to roar and claw at the ground as you make a mess of his pretty pink hole.  Every thrust forward makes his body flinch, knocking the wind out of him as you rapidly saw your [cock biggest] in and out of his hole.  Gobs of his internal lube drool out of his hole, cling to your shaft and drip down his sac.  Your [cock biggest] becomes a blur as you hit your top speed, making a sound akin to applause ring out as you brutally assault the demon’s hole.");
+				else {
+					outputText("\n\nYou are surprised you can even fit inside the demon’s tailhole.  The flesh wrapped around your [cock " + x1 + "] strains as you are halted by Akbal’s body.  You’re only able to fit a foot of your [cock " + x1 + "] into the demon, but you can feel his insides shifting.  The demon, stuffed beyond capacity, is somehow making room for the rest of your [cock " + x1 + "], and both of you can feel it.  The wriggling dickhole wrapped around your [cock " + x1 + "] is hot bliss, sliding, squeezing, and massaging your slowly advancing [cock " + x1 + "].  Beneath you, Akbal cringes and softly growls through clenched teeth as you sink, inch by inch, into his shifting innards.  When your trunk softly meshes against the demon’s upturned cheeks, a spasm rocks his body.  His insides tighten until you can’t move and Akbal shudders out a heavy orgasm.  You feel every spasm, every muscle contraction and every convulsion as the demon’s splatters his knees with rope after rope of creamy cat jizz.  Once Akbal’s hole relaxes again, you plant your [feet] and lean over his body with a mischievous grin.  With your hands at his waist to provide the necessary balance, you begin to jackhammer his insides, causing the demon to roar and claw at the ground as you make a mess of his pretty pink hole.  Every thrust forward makes his body flinch, knocking the wind out of him as you rapidly saw your [cock " + x1 + "] in and out of his hole.  Gobs of his internal lube drool out of his hole, cling to your shaft and drip down his sac.  Your [cock " + x1 + "] becomes a blur as you hit your top speed, making a sound akin to applause ring out as you brutally assault the demon’s hole.");
 				}
 
-				outputText("\n\nPushing down on the wrists tied behind his back, you press the demon’s chest flat to the ground as your [cock biggest] begins to swell.  Beneath you Akbal’s hole is fluttering, and you know he’s close.  With one last brutal thrust into the dominated demon-cat’s abused hole, you slam his entire body flat against the forest floor and unload.  Together the two of you howl till your collective voices are hoarse.  With a cringe you pull your [cock biggest] out of Akbal’s jizz dripping hole.");
-				outputText("\n\nAkbal lies on the ground, shivering as he rolls over.  The tied up demon jaguar’s stomach and the forest floor are covered in a thick coating of jizz, sticky strings even connect the demon’s chest to the puddle.  With heaving breath, the demon falls asleep as you gather your [armor] and leave.");
+				outputText("\n\nPushing down on the wrists tied behind his back, you press the demon’s chest flat to the ground as your [cock " + x1 + "] begins to swell.  Beneath you Akbal’s hole is fluttering, and you know he’s close.  With one last brutal thrust into the dominated demon-cat’s abused hole, you slam his entire body flat against the forest floor and unload.  Together the two of you howl till your collective voices are hoarse.  With a cringe you pull your [cock " + x1 + "] out of Akbal’s jizz dripping hole.");
+				outputText("\n\nAkbal lies on the ground, shivering as he rolls over.  The tied up demon jaguar’s stomach, and the forest floor are covered in a thick coating of jizz, sticky strings even connect the demon’s chest to the puddle.  With heaving breath, the demon falls asleep as you gather your [armor] and leave.");
+				player.sexReward("Default", "Dick", true, false);
+				dynStats("cor", 3);
+				doNext(camp.returnToCampUseOneHour);
 			}
-			//[if (hasVagina = true)
-			else
-			{
+
+			function vagF():void {
 				outputText(images.showImage("akbal-deepwoods-female-highspeed"));
-				outputText("\n\nYou grab Akbal’s leg and use it to roll the tied up demon over until his rigid length is pointing to the sky.  The tall and ribbed demon cat dick excretes a natural lube along with the white pre-cum drooling down its front.  It looks very inviting but the Jaguar’s face, his wide tongue and black lips, look even more so.");
-				outputText("\n\nYou stand in a squat above the demon’s face.  Before you even have the chance to smash your [vagOrAss] onto his lips, he lunges upward, shoving his face into you before you are ready.  A cascading rush ofecstasyy enters your body the moment his saliva touches your [vagOrAss].  You fall and the demon follows as you spread your legs wider, giving him an easier target for his bliss inducing oral ministrations.  He slathers your [vagOrAss] with a generous amount of saliva while using his wide tongue to lap at your exposed privates.  When he begins teasing your ");
+				outputText("\n\nYou grab Akbal’s leg and use it to roll the tied up demon over until his rigid length is pointing to the sky.  The tall and ribbed demon cat dick excretes a natural lube along with the white pre-cum drooling down its front.  It looks very inviting, but the Jaguar’s face, his wide tongue and black lips, look even more so.");
+				outputText("\n\nYou stand in a squat above the demon’s face.  Before you even have the chance to smash your [vagOrAss] onto his lips, he lunges upward, shoving his face into you before you are ready.  A cascading rush ofecstasyy enters your body the moment his saliva touches your [vagOrAss].  You fall, and the demon follows as you spread your legs wider, giving him an easier target for his bliss inducing oral ministrations.  He slathers your [vagOrAss] with a generous amount of saliva while using his wide tongue to lap at your exposed privates.  When he begins teasing your ");
 				if (player.hasVagina())
 					outputText("clit");
 				else
@@ -1622,24 +1431,21 @@ public class AkbalScene extends BaseContent
 				outputText(" with his long tongue, you begin to shiver.  Then you remember what it is you wanted to do.  Before he makes you cum, you shove his face away from you, pushing him onto his back with his cock once again standing tall.  Unable to contain yourself and draw this out any longer, you straddle the more than willing Jaguar demon and lower yourself onto his twitching erection without a second thought.");
 
 				//{tight/virgin vagorass}
-				if ((!player.hasVagina() && player.ass.analLooseness < 2) || (player.hasVagina() && player.looseness() <= 2))
-				{
-					outputText("\n\nWhen the mushroom-shaped head of Akbal’s monstrous dick touches your [vagOrAss], a lightning bolt of ecstasy shoots through your body.  The saliva coating your [vagOrAss] mixes with the fluid coating the demon’s dick and makes you call out from the very depths of your soul.  As if the heated, almost drug-like pleasure wasn’t enough, your [vagOrAss] is being stretched, somehow taking the full length of Akbal’s monster dick without a problem.  Once you’ve fully enveloped him, the barbs begn to vibrate, pulsing like sex beads that send you into overdrive.\n\nYou begin to bounce.  Your body cries out for more and you answer the call by bouncing up and down the entire length of Akbal’s wonderfully rigid dick as fast as you can.  Each time you crash your [vagOrAss] into his, there is a hard clap, and soon, you’re going so fast it sounds like excited applause.  Beneath you, Akbal shakes as you ride him faster and harder than he’s ever been ridden before.  The tightness of your [vagOrAss] seems to be rare treat to such a well-endowed demon.");
+				if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_LOOSE || player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_LOOSE) {
+					outputText("\n\nWhen the mushroom-shaped head of Akbal’s monstrous dick touches your [vagOrAss], a lightning bolt of ecstasy shoots through your body.  The saliva coating your [vagOrAss] mixes with the fluid coating the demon’s dick and makes you call out from the very depths of your soul.  As if the heated, almost drug-like pleasure wasn’t enough, your [vagOrAss] is being stretched, somehow taking the full length of Akbal’s monster dick without a problem.  Once you’ve fully enveloped him, the barbs begn to vibrate, pulsing like sex beads that send you into overdrive.\n\nYou begin to bounce.  Your body cries out for more, and you answer the call by bouncing up and down the entire length of Akbal’s wonderfully rigid dick as fast as you can.  Each time you crash your [vagOrAss] into his, there is a hard clap, and soon, you’re going so fast it sounds like excited applause.  Beneath you, Akbal shakes as you ride him faster and harder than he’s ever been ridden before.  The tightness of your [vagOrAss] seems to be rare treat to such a well-endowed demon.");
 				}
 				//{medium vagorass}
-				else if ((!player.hasVagina() && player.ass.analLooseness < 4) || (player.hasVagina() && player.looseness() < 4))
-				{
+				else if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_GAPING || player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_GAPING) {
 					outputText("\n\nWhen the mushroom shaped head of Akbal’s barbed dick touches your [vagOrAss], you feel the invasion with your entire body.  The saliva coating your spit-slick vagina reacts with the fluids coating Akbal’s dick, causing a chemically induced euphoria.  As if that wasn’t enough the barbs covering the shaft begin to vibrate, tingling your [vagOrAss] and driving you wild.\n\nYou plant your feet and begin riding Akbal for all you are worth.  With all your speed and strength, you smash your body into his, causing an unsteady, almost unending rhythm.  Beneath you Akbal shivers as you ride him so hard and fast that he can’t keep up. The demon’s toes curl, his eyes are even rolled into the back of his head.");
 				}
 				//{gaped vagorass}
-				else
-				{
+				else {
 					outputText("\n\nWhen the mushroom shaped head of Akbal’s gorgeous dick touches your [vagOrAss], you flinch.  The moment your spit-soaked ");
 					if (player.hasVagina())
 						outputText("vagina");
 					else
 						outputText("ass");
-					outputText(" touched the fluid-soaked demon dick, a tidal wave of pure euphoria cascaded through your entire being.  As if the chemical reaction wasn’t enough, the barbs on Akbal’s dick begin to vibrate, tickling and teasing your [vagOrAss].\n\nYou know what to do with a dick that feels that good: you plant your feet and begin bouncing up and down that ecstasy-inducing dick with all of your strength.  Soon you’re bouncing so fast your body meeting his sounds more like applause than two frisky partners going at it.  You can see the demon’s tongue as it rolls out of his mouth and his eyes as they roll to the back of his head.");
+					outputText(" touched the fluid-soaked demon dick, a tidal wave of pure euphoria cascaded through your entire being.  As if the chemical reaction wasn’t enough, the barbs on Akbal’s dick begin to vibrate, tickling and teasing your [vagOrAss].\n\nYou know what to do with a dick that feels that good: you plant your feet and begin bouncing up and down that ecstasy-inducing dick with all of your strength.  Soon you’re bouncing so fast your body meeting his sounds more like applause than two frisky partners going at it.  You can see the demon’s tongue as it rolls out of his mouth, and his eyes as they roll to the back of his head.");
 				}
 
 				if (player.hasVagina())
@@ -1647,12 +1453,12 @@ public class AkbalScene extends BaseContent
 				else
 					player.buttChange(16, true, true, false);
 
-				outputText("\n\nFrom his reaction you know he’s definitely enjoying this, but you could care less. He is nothing more than a living sex toy, a creature with a dick and tongue like no other which you are using to make your [vagOrAss] feel these electric sensations of cascading pleasure that steadily intensifies.  Beneath you, the demon begins to buck and soon you feel the heat of his exploding cock as he shoots you full of baby batter.  The euphoria you revelled it this entire time peeks.  Your body cringes involuntarily as your mouth opens in a silent scream.");
+				outputText("\n\nFrom his reaction you know he’s definitely enjoying this, but you couldn't care less. He is nothing more than a living sex toy, a creature with a dick and tongue like no other, which you are using to make your [vagOrAss] feel these electric sensations of cascading pleasure that steadily intensifies.  Beneath you, the demon begins to buck, and soon you feel the heat of his exploding cock as he shoots you full of baby batter.  The euphoria you revelled it this entire time peeks.  Your body cringes involuntarily as your mouth opens in a silent scream.");
 
 				//[if (hasCock = true)]
 				if (player.hasCock())
 					outputText("\n\nYou can’t help but grip [eachCock] as it explodes, painting Akbal’s chest with your creamy spooge.");
-					player.sexReward("default", "Dick", true, false);
+				player.sexReward("default", "Dick", true, false);
 				//[if (hasVagina = true)
 				if (player.hasVagina())
 					outputText("\n\nYour [vagina] releases a flood of creamy fluid as your body continues to convulse.  Your orgasm lasts for several minutes in which you paint Akbal with the evidence of how much he has pleased you.");
@@ -1662,20 +1468,18 @@ public class AkbalScene extends BaseContent
 					outputText("\n\nYour body begins to convulse as you call out. Your [ass] feels as though the demon’s dick is a lightning rod expelling a constant torrent of elation.");
 				outputText("\n\nYour [vagOrAss] is blissfully sore and crazy sensitive as you ease yourself off the demon’s wonderful dick.  With a smile on your [face] you gather your [armor] and turn to leave the forest.  Lost in giddy elation you walk, each movement sending an almost painful jolt of post orgasm pleasure through your [vagOrAss].  It isn’t until you hear the cackling of imps and goblins that you remember that you left Akbal bound and vulnerable... oops.");
 				if (player.hasVagina() && !player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
+				if (player.hasVagina()) player.sexReward("cum", "Vaginal");
+				else player.sexReward("cum", "Anal");
+				dynStats("cor", 3);
+				doNext(camp.returnToCampUseOneHour);
 			}
-			player.sexReward("cum");
-			dynStats("cor", 3);
-			doNext(camp.returnToCampUseOneHour);
 		}
 
 		//AMB Toughness Scene
 		//70
-		private function akbitchToughness():void
-		{
+		private function akbitchToughness():void {
 			clearOutput();
-			//[if (toughness > 70)]
-			outputText("You look down at your handywork and marvel at the fact that being ambushed and dominated has turned the demon on enough for him to shift forms.  Yet you wonder how much the demon jaguar really likes this type of thing...  You grab the vine hanging from his makeshift collar with a malicious grin spreading across your [face].  You step away and with a silent tug, you tell him to come.  His pride sparkles in his burning green eyes and he remains, baring his teeth in a low growl.  One more sudden yank causes him to begin wiggling on the ground, his hands being tied behind his back making it harder for him to move.  Every muscle on his lean body is tense and you know this self-proclaimed \"<i>god</i>\" hates you.  You smile as you watch his muscled ass shift beneath his spotted fur as he shortens the distance between the two of you.  Once he’s close enough you squat. Reaching down you grab his face and look into those desperately defiant eyes.  You can tell from the way he moves his hot little ass around that his erection is bothering him.  His eyes fall to your [feet] as he tries to stifle a purr.");
-
+			outputText("You look down at your handywork and marvel at the fact that being ambushed and dominated has turned the demon on enough for him to shift forms.  Yet you wonder how much the demon jaguar really likes this type of thing...  You grab the vine hanging from his makeshift collar with a malicious grin spreading across your [face].  You step away and with a silent tug, you tell him to come.  His pride sparkles in his burning green eyes, and he remains, baring his teeth in a low growl.  One more sudden yank causes him to begin wiggling on the ground, his hands being tied behind his back making it harder for him to move.  Every muscle on his lean body is tense, and you know this self-proclaimed \"<i>god</i>\" hates you.  You smile as you watch his muscled ass shift beneath his spotted fur as he shortens the distance between the two of you.  Once he’s close enough you squat. Reaching down you grab his face and look into those desperately defiant eyes.  You can tell from the way he moves his hot little ass around that his erection is bothering him.  His eyes fall to your [feet] as he tries to stifle a purr.");
 			outputText("\n\nAs the sound hits your ears, ");
 			if (player.hasCock())
 				outputText("[eachCock] twitches and begins spilling pre in preparation for what is to come.  Y");
@@ -1684,37 +1488,33 @@ public class AkbalScene extends BaseContent
 			outputText("ou can’t help but rub your [nipple] a little as the demon looks up at you with equal parts fear and defiance while trying to hide how hot you’re making him with a rumbling growl.  What a proud little bitch.");
 
 			outputText("\n\nYou instruct him to stop growling. He not only gets louder but snarls at you as well.  Well, that just won’t do.  You walk around the growling bitch and fall to your knees behind him.  You repeat the command and once again your order goes ignored.  You grab the demon by the scruff of his neck and raise your free hand into the sky before bringing it down with a loud smack that echoes through the trees.");
-
 			outputText("\n\n\"<i>RRRRAAAAAWWWWRRRR</i>\" Akbal screams as you look down at his now tightly clenched, fuzzy ass cheeks.  You rub the spot, enjoying the feel of the fleshy mound as the demon snarls.  Reaching up again you aim for the same spot, causing the demon to bellow again as your hand reconnects with a vengeance.");
-
-			outputText("\n\nYou tell him to shut up, punctuating each syllable with another blow to his posterior.  He howls for all he’s worth, not even trying to follow your order.  You aim a wicked blow at the unmolested cheek and he snarls, the mental voice he uses threatening you with all manners of perverse punishment.  It seems this bitch doesn’t get it, and his constant insults and threats have gotten on your last nerve.");
-
+			outputText("\n\nYou tell him to shut up, punctuating each syllable with another blow to his posterior.  He howls for all he’s worth, not even trying to follow your order.  You aim a wicked blow at the unmolested cheek, and he snarls, the mental voice he uses threatening you with all manners of perverse punishment.  It seems this bitch doesn’t get it, and his constant insults and threats have gotten on your last nerve.");
 			outputText("\n\nCasting your false veneer of calm aside, you begin to viciously spank the loud jaguar demon’s upturned cheeks with reckless abandon.  His body jerks while his legs kick wildly beneath you.  He tries to twist around, and you have to hold tight to his fur in order to keep the bitch face down.  Soon your palm is stinging, and he’s gritting his teeth in an effort to keep quiet.  After a few hard, body jarring test slaps you feel like maybe now the bitch is willing to comply.");
-
 			outputText("\n\n\"<i>Good boy,</i>\" you say as you rub the deliciously hot mound of flesh, an act that causes the demon to flinch as you make contact with his stinging buns.");
-
 			outputText("\n\n\"<i>You will pay for this, Champion,</i>\" Akbal promises, his mental voice dripping with venom.");
+			outputText("\n\nHow dare a bitch speak to its master in such a way?  Angered by his defiance, you begin to spank his upturned cheek again.  Without mercy or pity for the demon’s cries, you fill the air with the sound of his ass being slapped silly by the blur that is your free hand.  After a few minutes of serious palm-lashing, you switch hands and continue.  The demon continues to writhe and even begins begging for mercy.  He occasionally tries to quiet himself, but you are past mere compliance.  Only once your new hand is stinging as fiercely as your old one do you stop.  You grab his ass, and the demon’s entire body tenses, but he doesn’t make a sound.  This makes you smile.  As you rub and fondle his burning ass-cheeks, you let him know exactly who is in charge.  You tell him how much of a bitch you know he is.  You even laugh at him for telling you he was a \"<i>god</i>\".  He takes your verbal abuse silently and without retort.  With one slap for finality, you untie the demon’s hands.  He looks off across his clearing as if thinking about making a mad dash for it.  You tug his collar, silently reminding him he’s still bound to you.  A grin spreads across your [face] as he finally truly gives in.");
+			sceneHunter.passCheckOnce();
+			sceneHunter.selectGender(
+				curry(sceneHunter.callBigSmall, dickF, 12, 7, "length", 20), vagF, null, null, 1,
+				player.cockThatFits(20, "length") >= 0, "Too big! (Req. a dick shorter than 20 inches)");
 
-			outputText("\n\nHow dare a bitch speak to its master in such a way?  Angered by his defiance, you begin to spank his upturned cheek again.  Without mercy or pity for the demon’s cries, you fill the air with the sound of his ass being slapped silly by the blur that is your free hand.  After a few minutes of serious palm-lashing, you switch hands and continue.  The demon continues to writhe and even begins begging for mercy.  He occasionally tries to quiet himself but you are past mere compliance.  Only once your new hand is stinging as fiercely as your old one do you stop.  You grab his ass, and the demon’s entire body tenses but he doesn’t make a sound.  This makes you smile.  As you rub and fondle his burning ass-cheeks, you let him know exactly who is in charge.  You tell him how much of a bitch you know he is.  You even laugh at him for telling you he was a \"<i>god</i>\".  He takes your verbal abuse silently and without retort.  With one slap for finality, you untie the demon’s hands.  He looks off across his clearing as if thinking about making a mad dash for it.  You tug his collar, silently reminding him he’s still bound to you.  A grin spreads across your [face] as he finally truly gives in.");
-
-			//[if (hasCock = true)]
-			if (player.hasCock())
-			{
+			//====================================================================================
+			function dickF(x:int):void {
+				var x1:int = x + 1;
 				outputText(images.showImage("akbal-deepwoods-male-hightoughness"));
-				outputText("\n\nYou tell the demon to put his ass up. When he does, you aid him by shoving his chest into the ground, making sure he arches his back properly.  His furry ass naturally parts, revealing his little dripping pink rosebud.  You begin to shed your [armor], and his hole flexes a few times, causing a creamy lube to drip down his scrotum.  [EachCock] is rigid as you expose yourself to the air.  Akbal wiggles his ass at you and you realize how badly he wants you inside him.  It appears this demon has decided to be a good little bitch.  You grab your [cock biggest] and grin as you lower yourself to mount him.");
-				var x:int = player.biggestCockIndex();
-
-				//{cocklength < 7}
+				outputText("\n\nYou tell the demon to put his ass up. When he does, you aid him by shoving his chest into the ground, making sure he arches his back properly.  His furry ass naturally parts, revealing his little dripping pink rosebud.  You begin to shed your [armor], and his hole flexes a few times, causing a creamy lube to drip down his scrotum.  [EachCock] is rigid as you expose yourself to the air.  Akbal wiggles his ass at you, and you realize how badly he wants you inside him.  It appears this demon has decided to be a good little bitch.  You grab your [cock " + x1 + "] and grin as you lower yourself to mount him.");
+			//{cocklength < 7}
 				if (player.cocks[x].cockLength < 7)
-					outputText("\n\nAs you push your [cockHead biggest] into the jaguar demon, he begins to purr but quickly stops, remembering he’s supposed to be quiet.  The lube that drips from his tight rectal tube heats up as you slide the rigid length of [oneCock] through his fuck tunnel until you’ve buried your entire length into his hungry tailhole.  You aim a smack at his still tender ass, causing the passage to tighten as two hollows appear in his squeezing cheeks.  You begin pump your [cock] in and out of his tight hole slowly, reveling in the heated wetness of the demon’s bowels.");
+					outputText("\n\nAs you push your [cock " + x1 + "] into the jaguar demon, he begins to purr but quickly stops, remembering he’s supposed to be quiet.  The lube that drips from his tight rectal tube heats up as you slide the rigid length of [oneCock] through his fuck tunnel until you’ve buried your entire length into his hungry tailhole.  You aim a smack at his still tender ass, causing the passage to tighten as two hollows appear in his squeezing cheeks.  You begin pump your [cock] in and out of his tight hole slowly, reveling in the heated wetness of the demon’s bowels.");
 				//{cockLength between 7 and 12}
 				else if (player.cocks[x].cockLength < 12)
-					outputText("\n\nWhen you push your [cockHead biggest] into the jaguar demon he flinches and barely manages to stay quiet.  The lube that drips from his anal opening helps you stuff your [cock biggest] into his tight hole.  It takes some trying, but once you’ve sunk all of your [cock biggest] into the demon’s back door, you aim a slap at his still tender ass, causing the demon to tighten his living dick tube of a tailhole around your deeply embedded [cock biggest].  You begin to slowly rock back and forth, enjoying the feeling of his wet rectal passage squeezing your [cock biggest].");
+					outputText("\n\nWhen you push your [cock " + x1 + "] into the jaguar demon he flinches and barely manages to stay quiet.  The lube that drips from his anal opening helps you stuff your [cock " + x1 + "] into his tight hole.  It takes some trying, but once you’ve sunk all of your [cock " + x1 + "] into the demon’s back door, you aim a slap at his still tender ass, causing the demon to tighten his living dick tube of a tailhole around your deeply embedded [cock " + x1 + "].  You begin to slowly rock back and forth, enjoying the feeling of his wet rectal passage squeezing your [cock " + x1 + "].");
 				//{cockLength > 12}
 				else
-					outputText("\n\nWhen you push your [cockHead biggest] into the jaguar demon his hips swerve, running from your [cock biggest].  You smack his tender rump before grabbing his slender hips and jerking him back into position.  Grabbing the base of his tail with one hand and your [cock biggest] in the other, you slowly force yourself into the bitch’s tight hole.  It’s hard work getting your [cock biggest] to slide into the tight hole.  That vicious spanking he just received isn’t making him the most receptive bitch either.  The demon’s passage quivers against your [cock biggest] as it slowly slides into him.  Once you’ve got a foot of your [cock biggest] into his body your slow advance is halted.  The tight fleshy glove wrapped around the first twelve inches of your [cock biggest] begins to shift.  As you begin to sink more of your [cock biggest] into Akbal you can feel the bitch’s body making more room.  After aiming a wicked slap to his abused cheeks you grab his hips and force the rest of your [cock biggest] into him, stretching the squirming and snarling demon to the limit.  You remind him to shut up, and the demon’s hands fly to his mouth in an attempt to silence himself and avoid further punishment.  When your trunk mashes against the demon’s tender ass, you feel his anal ring clench tight and begin to spasm.  Unable to contain himself, Akbal roars as your giant cock causes him to paint the grass beneath the two of you white.  You laugh as your embedded [cock biggest] is milked by the convulsing passage.  Once that is over he goes limp, forcing you to smack his muscled cheeks again and jerk his tender ass back into the proper position.  Now that he’s back on track you begin to rock back and forth, his passage now far more relaxed and easier to penetrate than before.");
+					outputText("\n\nWhen you push your [cock " + x1 + "] into the jaguar demon his hips swerve, running from your [cock " + x1 + "].  You smack his tender rump before grabbing his slender hips and jerking him back into position.  Grabbing the base of his tail with one hand, and your [cock " + x1 + "] in the other, you slowly force yourself into the bitch’s tight hole.  It’s hard work getting your [cock " + x1 + "] to slide into the tight hole.  That vicious spanking he just received isn’t making him the most receptive bitch either.  The demon’s passage quivers against your [cock " + x1 + "] as it slowly slides into him.  Once you’ve got a foot of your [cock " + x1 + "] into his body your slow advance is halted.  The tight fleshy glove wrapped around the first twelve inches of your [cock " + x1 + "] begins to shift.  As you begin to sink more of your [cock " + x1 + "] into Akbal you can feel the bitch’s body making more room.  After aiming a wicked slap to his abused cheeks you grab his hips and force the rest of your [cock " + x1 + "] into him, stretching the squirming and snarling demon to the limit.  You remind him to shut up, and the demon’s hands fly to his mouth in an attempt to silence himself and avoid further punishment.  When your trunk mashes against the demon’s tender ass, you feel his anal ring clench tight and begin to spasm.  Unable to contain himself, Akbal roars as your giant cock causes him to paint the grass beneath the two of you white.  You laugh as your embedded [cock " + x1 + "] is milked by the convulsing passage.  Once that is over he goes limp, forcing you to smack his muscled cheeks again and jerk his tender ass back into the proper position.  Now that he’s back on track you begin to rock back and forth, his passage now far more relaxed and easier to penetrate than before.");
 
-				outputText("\n\nNow that the little bitch is somewhat comfortable, you increase the tempo.  With the full length of your [cock biggest], you begin to pound the demon with echoing claps.  Every time your body slams into his upturned rump, Akbal flinches; several times he lets out a little sexy whimper.  The combination of you plowing into his tender ass cheeks and roughly fucking his tight hole has Akbal almost failing to keep quiet.  You slap his little ass again, and he lets out a cry before desperately trying to shut himself up.  The dripping passage has your [cock biggest] pulsing with need.  As you continue to deep dick the jaguar, he suddenly howls.  His ass shoves itself backwards and clamps down around most of your [cock biggest] as he blasts the ground with ");
+				outputText("\n\nNow that the little bitch is somewhat comfortable, you increase the tempo.  With the full length of your [cock " + x1 + "], you begin to pound the demon with echoing claps.  Every time your body slams into his upturned rump, Akbal flinches; several times he lets out a little sexy whimper.  The combination of you plowing into his tender ass cheeks and roughly fucking his tight hole has Akbal almost failing to keep quiet.  You slap his little ass again, and he lets out a cry before desperately trying to shut himself up.  The dripping passage has your [cock " + x1 + "] pulsing with need.  As you continue to deep dick the jaguar, he suddenly howls.  His ass shoves itself backwards and clamps down around most of your [cock " + x1 + "] as he blasts the ground with ");
 				if (player.cocks[x].cockLength > 12)
 					outputText("another");
 				else
@@ -1723,40 +1523,39 @@ public class AkbalScene extends BaseContent
 
 				//{corruption < 90}
 				if (player.cor < 90)
-					outputText("\n\nThe convulsing demon hole around your [cock biggest] makes you groan as Akbal’s orgasm begin to subside, allowing you to move around in his hot, wet rectal passage once again.");
+					outputText("\n\nThe convulsing demon hole around your [cock " + x1 + "] makes you groan as Akbal’s orgasm begin to subside, allowing you to move around in his hot, wet rectal passage once again.");
 				//{corruption > 90}
 				outputText("\n\nYou grab his hips and forcibly pound the little bitch’s quivering anal ring out of shape, reveling in the pulsating pressure as Akbal roars beneath you, a sound of mixed pain and ecstasy as you decimate his clenching hole with brutal thrusts.");
 
-				outputText("\n\nAkbal claws at the ground, roaring as you slam your hips into his used and abused hole with a vengeance.  You feel [eachCock] pulsating with need as you pound the demon, brutally forcing your [cock biggest] through his demonic tailhole until you reach the point of no return.");
+				outputText("\n\nAkbal claws at the ground, roaring as you slam your hips into his used and abused hole with a vengeance.  You feel [eachCock] pulsating with need as you pound the demon, brutally forcing your [cock " + x1 + "] through his demonic tailhole until you reach the point of no return.");
 
-				//{if player has dog cock + knot}
-				if (player.hasKnot(x))
-					outputText("\n\nAkbal hisses as you force your swollen knot into his decimated anal ring.  Your entire body cringes as the swollen flesh is engulfed in his hot wet innards.  Your [cock biggest] explodes with the force of a megaton bomb.  With a wordless scream, you shiver as you fill Akbal full of baby batter.  As your orgasm subsides, you fall into his back, grinding your knot around in his corked bowls until the swelling goes down enough for you to tug your [cock biggest] out of his hole, sending a cascade of your seed down his gaped tailhole.");
 				//{if player has horse dick}
-				else if (player.cocks[x].cockType == CockTypesEnum.HORSE)
-					outputText("\n\nAkbal grabs his face to keep quiet again as your [cock biggest] spears into him and flares.  Trembling, you grab his hips and rear back, blasting your baby batter into the demon’s stuffed bowels with clenched teeth.  You can feel Akbal’s innards convulsing around each segment of your [cock biggest] as he milks it for all he is worth.");
+				if (player.cocks[x].cockType == CockTypesEnum.HORSE)
+					outputText("\n\nAkbal grabs his face to keep quiet again as your [cock " + x1 + "] spears into him and flares.  Trembling, you grab his hips and rear back, blasting your baby batter into the demon’s stuffed bowels with clenched teeth.  You can feel Akbal’s innards convulsing around each segment of your [cock " + x1 + "] as he milks it for all he is worth.");
 				//{if player has tentacle dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.TENTACLE)
-					outputText("\n\nYou can hear nothing but the sound of Akbal roaring as you shove the full length of your [cock biggest] into his battered hole.  He grits his teeth as your [cock biggest] goes ballistic, rearranging his intestines with a mad dance that causes the demon to shiver out another smaller orgasm.  The mad dance stretches his hole, causing your seed to spill down your [legs], and his scrotum as you grind your [cock biggest] around in his decimated hole.");
+					outputText("\n\nYou can hear nothing but the sound of Akbal roaring as you shove the full length of your [cock " + x1 + "] into his battered hole.  He grits his teeth as your [cock " + x1 + "] goes ballistic, rearranging his intestines with a mad dance that causes the demon to shiver out another smaller orgasm.  The mad dance stretches his hole, causing your seed to spill down your [legs], and his scrotum as you grind your [cock " + x1 + "] around in his decimated hole.");
 				//{if player has cat dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.CAT)
-					outputText("\n\nYou feel your [cock biggest] begin to jump around in Akbal’s wrecked tailhole, and he suddenly pushes back, enveloping your entire [cock biggest] and squeezing.  You roar as the demon’s flexing anal muscles send you over the edge of ecstasy.  You blast your seed into his squeezing bowls with violent convulsions that rock your body like hammer blows.  Even after your climax has fully fizzled out, the little bitch still squeezes your softening [cock biggest], making your baby batter stream down your [legs] and his.");
+					outputText("\n\nYou feel your [cock " + x1 + "] begin to jump around in Akbal’s wrecked tailhole, and he suddenly pushes back, enveloping your entire [cock " + x1 + "] and squeezing.  You roar as the demon’s flexing anal muscles send you over the edge of ecstasy.  You blast your seed into his squeezing bowls with violent convulsions that rock your body like hammer blows.  Even after your climax has fully fizzled out, the little bitch still squeezes your softening [cock " + x1 + "], making your baby batter stream down your [legs] and his.");
 				//{if player has dragon dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.DRAGON)
-					outputText("\n\nYou pound the demon’s muscular ass with steadily mounting force, sawing the bulb at the base of your [cock biggest] in and out of his hole and making him yelp with each battering ram like hammer blow to his insides.  With a dragon’s roar you climax, filling the demon’s shivering bowls with your funky seed as he shivers from the rough fucking and spanking you’ve given him.  Streams of your white goo spill down his scrotum and your [legs] making you smile as the demon goes limp beneath you.");
+					outputText("\n\nYou pound the demon’s muscular ass with steadily mounting force, sawing the bulb at the base of your [cock " + x1 + "] in and out of his hole and making him yelp with each battering ram like hammer blow to his insides.  With a dragon’s roar you climax, filling the demon’s shivering bowls with your funky seed as he shivers from the rough fucking and spanking you’ve given him.  Streams of your white goo spill down his scrotum, and your [legs] making you smile as the demon goes limp beneath you.");
 				//{If player has Lizard dick}
 				else if (player.cocks[x].cockType == CockTypesEnum.LIZARD)
-					outputText("\n\nAkbal’s insides quiver in time with your mad thrusts.  You watch the bumpy, purple blur of your [cock biggest] sawing in and out of Akbal until the sensation causes you to throw you head back.  With a groan your [cock biggest] explodes, sending torrents of spunk into Akbal’s bowls as you shove in and hold.  Your body trembles as you yank your still spurting [cock biggest] out of Akbal’s hole and paint his round muscular abused cheeks with a few gouts of jizz.");
+					outputText("\n\nAkbal’s insides quiver in time with your mad thrusts.  You watch the bumpy, purple blur of your [cock " + x1 + "] sawing in and out of Akbal until the sensation causes you to throw you head back.  With a groan your [cock " + x1 + "] explodes, sending torrents of spunk into Akbal’s bowls as you shove in and hold.  Your body trembles as you yank your still spurting [cock " + x1 + "] out of Akbal’s hole and paint his round muscular abused cheeks with a few gouts of jizz.");
+				//{if player has knot}
+				else if (player.hasKnot(x))
+					outputText("\n\nAkbal hisses as you force your swollen knot into his decimated anal ring.  Your entire body cringes as the swollen flesh is engulfed in his hot wet innards.  Your [cock " + x1 + "] explodes with the force of a megaton bomb.  With a wordless scream, you shiver as you fill Akbal full of baby batter.  As your orgasm subsides, you fall into his back, grinding your knot around in his corked bowls until the swelling goes down enough for you to tug your [cock " + x1 + "] out of his hole, sending a cascade of your seed down his gaped tailhole.");
 				//{if player has human/kanga dick}
 				else
-					outputText("\n\nAs your [cock biggest] paints Akbal’s anal walls white, you continue to fuck his decimated ass.  Each spurt from your brings a wave of relief as you slam into the demon’s hole with freight train force, pounding his tender ass as you shoot cream into his quivering hole.  As your orgasm subsides, you aim a last slap at the demon’s ass, one that causes him to squeeze his abused cheeks and send cream rushing past your embedded [cock biggest] and down his furry scrotum.");
+					outputText("\n\nAs your [cock " + x1 + "] paints Akbal’s anal walls white, you continue to fuck his decimated ass.  Each spurt from your brings a wave of relief as you slam into the demon’s hole with freight train force, pounding his tender ass as you shoot cream into his quivering hole.  As your orgasm subsides, you aim a last slap at the demon’s ass, one that causes him to squeeze his abused cheeks and send cream rushing past your embedded [cock " + x1 + "] and down his furry scrotum.");
 
-				outputText("\n\nAs you rise, Akbal goes limp. You cannot help but chuckle as looking down, you realize you have made quite the mess.  The demon’s body trembles as he looks back, his eyes questioning if his bitch duties are done. Satisfied you gather your [armor] and leave Akbal to it. When you reach the edge of the forest you hear the sound of him asserting his dominance over an Imp.  You stop and listen to the sound of the demon trying to reclaim his manhood, knowing the entire time his ass is sore and dripping, reminding him of how much of a bitch he truly is.");
+				outputText("\n\nAs you rise, Akbal goes limp. You cannot help but chuckle as looking down, you realize you have made quite the mess.  The demon’s body trembles as he looks back, his eyes questioning if his bitch duties are done. Satisfied you gather your [armor] and leave Akbal to it. When you reach the edge of the forest, you hear the sound of him asserting his dominance over an Imp.  You stop and listen to the sound of the demon trying to reclaim his manhood, knowing the entire time his ass is sore and dripping, reminding him of how much of a bitch he truly is.");
 				player.sexReward("Default", "Dick", true, false);
 			}
-			//{female/genderless}
-			else
-			{
+
+			function vagF():void {
 				outputText(images.showImage("akbal-deepwoods-female-highspeed"));
 				outputText("\n\nYou flip the demon over; he barely suppresses a hiss as his sore ass cheeks hit the forest floor.  With the vine that acts as a leash to his little collar, you straddle his face, tugging the demon’s muzzle into your [vagOrAss].");
 				outputText("\n\nLike an obedient bitch, he follows your silent command without hesitation.  As the wide jaguar tongue laps at your [vagOrAss], you grind into the sensation of exploding pleasure.  His glorious saliva has you quivering in moments.  If that was not enough, he masterfully manipulates your [vagOrAss], masterfully tickling your ");
@@ -1773,29 +1572,26 @@ public class AkbalScene extends BaseContent
 					outputText("muscular");
 				else
 					outputText("voluptuous");
-				outputText(" body until he reaches your [fullChest].  After a second of feeling around he finds your [nipples].");
+				outputText(" body until he reaches your [fullChest].  After a second of feeling around, he finds your [nipples].");
 
 				//[if (hasNippleCunts = False)]
 				if (!player.hasFuckableNipples())
 					outputText("\n\nThe demon gently teases your erect [nipples] with his hands before rubbing your [fullChest] in large circular motions.  The feeling of his soft fur gliding across your " + player.skinFurScales() + " in combination with his mouth and tongue attacking your [vagOrAss] is making your body convulse.");
 				else
-					outputText("\n\nThe demon lets out a sound of surprise against your [vagOrAss] as he notices your [nipples].  He delves a finger into your [nipple] and swabs the moist cavity with a curious finger.  After a few moments of playing with your [nipples] he begins rubbing your [fullChest] in large circular motions.  He takes time to tease each of your tits with the feeling of his soft fur until you can take no more.");
+					outputText("\n\nThe demon lets out a sound of surprise against your [vagOrAss] as he notices your [nipples].  He delves a finger into your [nipple] and swabs the moist cavity with a curious finger.  After a few moments of playing with your [nipples], he begins rubbing your [fullChest] in large circular motions.  He takes time to tease each of your tits with the feeling of his soft fur until you can take no more.");
 
 				outputText("\n\nYou shove the demon away from you, sliding down his body with a sexy little grin.  You waste no time reaching for his barbed dick and aiming it at your [vagOrAss] before squatting down until his rigid length is poised at your entrance.");
 
 				//{tight/virgin Vag/ass}
-				if ((!player.hasVagina() && player.ass.analLooseness < 2) || (player.hasVagina() && player.looseness() <= 2))
-				{
-					outputText("\n\nAs your [vagOrAss] touches the mushroom-shaped head of Akbal’s barbed dick, your body is hit with an explosion of pleasure.  The sensation is pure ecstasy, blasting through your body from your [vagOrAss].  Your [vagOrAss] begins to stretch, the mystic mixture of Akbal’s spit and the lube soaking his erect dick allowing you to take the gargantuan barbed dick without a problem.  The feeling of your flesh widening to encompass Akbal’s dick is both alien and wonderful.  Once you can take the entire length you begin bouncing up and down his euphoria inducing dick with a huge grin on your [face].");
+				if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_LOOSE || player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_LOOSE) {
+					outputText("\n\nAs your [vagOrAss] touches the mushroom-shaped head of Akbal’s barbed dick, your body is hit with an explosion of pleasure.  The sensation is pure ecstasy, blasting through your body from your [vagOrAss].  Your [vagOrAss] begins to stretch, the mystic mixture of Akbal’s spit, and the lube soaking his erect dick allowing you to take the gargantuan barbed dick without a problem.  The feeling of your flesh widening to encompass Akbal’s dick is both alien and wonderful.  Once you can take the entire length you begin bouncing up and down his euphoria inducing dick with a huge grin on your [face].");
 				}
 				//{medium vag/ass}
-				else if ((!player.hasVagina() && player.ass.analLooseness < 4) || (player.hasVagina() && player.looseness() < 4))
-				{
+				else if (!player.hasVagina() && player.ass.analLooseness < AssClass.LOOSENESS_GAPING || player.hasVagina() && player.looseness() < VaginaClass.LOOSENESS_GAPING) {
 					outputText("\n\nAs your [vagOrAss] touches the mushroom-shaped head of Akbal’s barbed dick, your body is hit with an explosion of ecstasy.  The feeling of Akbal’s giant sex organ just sitting inside your [vagOrAss] sends waves of pure pleasure through your body.  Throwing your head back you ride the demon for all you are worth.");
 				}
 				//{Gaped vag/ass}
-				else
-				{
+				else {
 					outputText("\n\nAs your [vagOrAss] touches the wet, mushroom-shaped head of Akbal’s barbed dick, you begin to swoon.  The feeling of his lube-covered dick touching your spit soaked [vagOrAss] is like an ocean of pleasure crashing through your body.  You allow yourself to be swept away by the tidal wave and begin sliding up and down Akbal’s dick with practiced ease.  With a grimace of pure euphoria plastered on your face, you ride the demon with everything you’ve got.");
 				}
 				//{cunt or butt change}
@@ -1804,7 +1600,7 @@ public class AkbalScene extends BaseContent
 				else
 					player.buttChange(16, true, true, false);
 
-				outputText("\n\nThe demon begins trying to slide his dick up into you to increase his own pleasure.  With a single raise of your hand, he stops and you’re free to control your own pace, and with that freedom, you increase tempo until the demon’s teeth are clenched and his toes curled.  He has to fight to keep still, which amuses you, as his fear of more pain wins out against his legendary lust.  Then you feel it.  His body begins to convulse.  You feel his dick explode inside you, filling you with a hot warmth that intensifies the chemical reactions taking place inside your [vagOrAss].");
+				outputText("\n\nThe demon begins trying to slide his dick up into you to increase his own pleasure.  With a single raise of your hand, he stops, and you’re free to control your own pace, and with that freedom, you increase tempo until the demon’s teeth are clenched, and his toes curled.  He has to fight to keep still, which amuses you, as his fear of more pain wins out against his legendary lust.  Then you feel it.  His body begins to convulse.  You feel his dick explode inside you, filling you with a hot warmth that intensifies the chemical reactions taking place inside your [vagOrAss].");
 
 				outputText("\n\nWith a shrill cry you cum, your [vagOrAss] erupts, sending a cascade of wetness down Akbal’s embedded shaft.");
 				//[if (hasCock = True)
@@ -1814,8 +1610,10 @@ public class AkbalScene extends BaseContent
 
 				outputText("\n\nWithout a backwards glance, you gather your [armor] and leave the forest with a big smile on your [face].");
 			}
+
 			if (player.hasVagina() && !player.isGoblinoid()) player.knockUp(PregnancyStore.PREGNANCY_IMP, PregnancyStore.INCUBATION_IMP, 101);
-			player.sexReward("cum");
+			if (player.hasVagina()) player.sexReward("cum", "Vaginal");
+			else player.sexReward("cum", "Anal");
 			dynStats("cor", 3);
 			doNext(camp.returnToCampUseOneHour);
 		}

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -571,7 +571,7 @@ package classes.Scenes.Areas.Forest
 		}
 
 		private function loseToAckballllllz():void {
-			if (player.isTaur) {
+			if (player.isTaur()) {
 				akbalRapesTaurs();
 				return;
 			}

--- a/classes/classes/Scenes/Areas/Forest/AkbalScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AkbalScene.as
@@ -703,7 +703,7 @@ package classes.Scenes.Areas.Forest
 			outputText("You ready your [weapon] and prepare to battle the demon jaguar.");
 			//[battle ensues]
 			startCombat(new Akbal());
-			flags[kFLAGS.PLAYER_RESISTED_AKBAL]++;
+			flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] = 0;
 		}
 
 		//[Submit]
@@ -714,19 +714,21 @@ package classes.Scenes.Areas.Forest
 			flags[kFLAGS.AKBAL_SUBMISSION_STATE] = 2;
 			flags[kFLAGS.AKBAL_BITCH_Q] = -1;
 			//Big booty special
-			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] > 5 && flags[kFLAGS.PLAYER_RESISTED_AKBAL] < 2 && player.butt.type >= 13 && player.tone < 80) {
+			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] > 5 && player.butt.type >= 13 && player.tone < 80) {
 				akbalBigButtSubmit();
 				return;
 			}
 			clearOutput();
+			sceneHunter.print("Check failed: at least 5 submissions without resists, big butt (13), low muscle tone (80)");
+			sceneHunter.print("Fork: nagas, taurs, others");
 			//Naga variant goez here
 			if (player.isNaga()) {
 				outputText(images.showImage("akbal-deepwoods-naga-sumbitanal"));
-				outputText("After a few moments of thinking you nod to Akbal and the masculine voice in your head commands you to disrobe. You take off your [armor], setting it aside moments before the demon is upon you.\n\n");
+				outputText("After a few moments of thinking you nod to Akbal, and the masculine voice in your head commands you to disrobe. You take off your [armor], setting it aside moments before the demon is upon you.\n\n");
 
-				outputText("Akbal pushes you face first into the ground and places his forward paws on your back, pinning your chest against the ground. He removes the paw and you attempt to reposition yourself only to have your body pushed back down, a silent command for you to stay in this position.  You can't help but squirm a little as your bottom half is bunched up under your abdomen, putting your [butt] in the air.\n\n");
+				outputText("Akbal pushes you face-first into the ground and places his forward paws on your back, pinning your chest against the ground. He removes the paw, and you attempt to reposition yourself only to have your body pushed back down, a silent command for you to stay in this position.  You can't help but squirm a little as your bottom half is bunched up under your abdomen, putting your [butt] in the air.\n\n");
 
-				outputText("His paws slide to your waist, melting into hands along the way. You look from beneath your arm and watch as Akbal's body changes, becoming more humanoid.  Once his transformation is complete he gets on his knees behind you and roughly pulls your upturned bottom half back.  When he shoves his face into your [butt] you flinch at the sudden and inexplicably erotic feeling.\n\n");
+				outputText("His paws slide to your waist, melting into hands along the way. You look from beneath your arm and watch as Akbal's body changes, becoming more humanoid.  Once his transformation is complete he gets on his knees behind you and roughly pulls your upturned bottom halfback.  When he shoves his face into your [butt] you flinch at the sudden and inexplicably erotic feeling.\n\n");
 
 				outputText("He works his slippery wet tongue into your " + assholeDescript() + ", greedily lapping at your exposed backside as if it were a quickly-melting ice cream cone. The sensation causes you to groan as you push back against the tongue, suddenly lost in ecstasy. A part of your long tail wraps around his waist, holding him there as you revel in the sensation of being rimmed by a pro.  You even arch your back, allowing his long, thick jaguar tongue to penetrate deeper into your " + assholeDescript() + ". You feel his saliva, thick and warm like melted candy, sliding inside of you and coating your insides.\n\n");
 
@@ -734,13 +736,13 @@ package classes.Scenes.Areas.Forest
 				outputText("A sudden warmth heats your innards, making you shiver in ecstasy.  Akbal takes a moment to uncoil your bottom half from around his chest before he rises to mount you. A single paw shoves your lifted chest and face back into the dirt, causing cold earth to cling to your body as Akbal gets into position above you.\n\n");
 
 				//(Small/Virgin Pucker)
-				if (player.ass.analLooseness < 3) {
+				if (player.ass.analLooseness < AssClass.LOOSENESS_LOOSE) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only insanely large but its head is covered in a dozen tiny barbs. You grit your teeth, expecting pain and yet, thanks to the weird saliva he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 
 					outputText("The feeling of being stretched by Akbal's long, slimy member makes you shudder, the weird spit even heats up, creating a steamy warmth inside you as Akbal's equally hot member stretches you out and makes your body spasm slightly. After a few slow, shallow strokes you begin to feel the barbs vibrate. This vibrating drives you insane, and the wicked looking barbs feel more like humming sex beads than punishing spikes. When Akbal picks up the pace you grit your teeth as you are stretched beyond your natural limits.");
 				}
 				//(Medium Pucker)
-				else if (player.ass.analLooseness < 5) {
+				if (player.ass.analLooseness < AssClass.LOOSENESS_GAPING) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs. Yet, thanks to the weird spit he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 
 					outputText("Akbal's titanic member stretches your " + assholeDescript() + " and makes you groan beneath him, reveling in the slick heat and fullness of your bowels. His saliva heats up, creating a steamy,pleasurable warmth inside your body. As he begins to pump his huge sex organ in and out of you the barbs covering his head begin to vibrate and hit your body with tidal waves of unbearable pleasure, feeling more like vibrating sex beads than punishing spikes. Your body begins to act of its own accord, your [butt] grinding against his thrusts as his large sex pump slides in with his trunk slamming into your [butt] in rhythmic, echoing claps.");
@@ -749,19 +751,19 @@ package classes.Scenes.Areas.Forest
 				else {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs. When Akbal begins to penetrate you he is surprised when his trunk suddenly slams into your [butt], the sudden invasion causing you to croon.\n\n");
 
-					outputText("The weird spit he slathered your insides with begins to heat up instantly and the barbs covering his cock head start vibrating. The sensation of the vibrating barbs is like a dozen small slimy sex beads spinning and shaking as they are pushed inside you. Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing your body to slide forward through the dirt. You try to meet his deep thrusts but the jaguar fucks you with speed and force befitting a cheetah and the constantly vibrating barbs make your body shiver with each hammer blow to your insides.");
+					outputText("The weird spit he slathered your insides with begins to heat up instantly, and the barbs covering his cock head start vibrating. The sensation of the vibrating barbs is like a dozen small slimy sex beads spinning and shaking as they are pushed inside you. Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing your body to slide forward through the dirt. You try to meet his deep thrusts, but the jaguar fucks you with speed and force befitting a cheetah, and the constantly vibrating barbs make your body shiver with each hammer blow to your insides.");
 				}
 				player.buttChange(monster.cockArea(0), true);
 				outputText("\n\n");
 
 				//(ending)
-				outputText("Akbal works his hips fast, piston-pumping his long demon-cat dick in and out of your " + assholeDescript() + ". Your voice rises and falls with his frantic thrusts. Your body is racked by orgasm after orgasm and soon you're lying on your chest and knees in a pool of your own love juices.\n\n");
+				outputText("Akbal works his hips fast, piston-pumping his long demon-cat dick in and out of your " + assholeDescript() + ". Your voice rises and falls with his frantic thrusts. Your body is racked by orgasm after orgasm, and soon you're lying on your chest and knees in a pool of your own love juices.\n\n");
 
-				outputText("Akbal releases a harsh growl and you feel the large feline member twitching and swelling inside you. A growl sounds in your own chest as the hot, corrupted seed of the demon cat shoots into you. Despite having reached his climax the jaguar's piston-pumping doesn't slow until he's erupted no less than six times, masterfully working your hole the entire time.\n\n");
+				outputText("Akbal releases a harsh growl, and you feel the large feline member twitching and swelling inside you. A growl sounds in your own chest as the hot, corrupted seed of the demon cat shoots into you. Despite having reached his climax the jaguar's piston-pumping doesn't slow until he's erupted no less than six times, masterfully working your hole the entire time.\n\n");
 
 				outputText("After his last massive eruption you feel the jaguar demon pull out, releasing even more of his copious loads from your happy hole in an oddly satisfying cascade of thick white cream that rushes like a waterfall down your body.\n\n");
 
-				outputText("The jaguar demon no longer seems to mind your presence in his territory as he drapes his tired body over yours and the two of you fall into a sex-induced coma.");
+				outputText("The jaguar demon no longer seems to mind your presence in his territory as he drapes his tired body over yours, and the two of you fall into a sex-induced coma.");
 				//[+ 4-12 Corruption]
 				dynStats("cor", 4 + rand(8));
 				//[+ 1-2 Speed]
@@ -795,7 +797,7 @@ package classes.Scenes.Areas.Forest
 
 				outputText("The jaguar demon begins pushing you forward with his powerful hips, his demon-cat-dick sliding up the crevice of your [butt].  He steers you towards a tree, forcing you chest-first against the rough bark.\n\n");
 
-				outputText("Looking back you watch Akbal bend low, losing sight of the jaguar demon as he disappears behind you.  For a moment you wonder what he's doing but soon you feel him shove his face into your [butt] with a snarl.  He begins working his slippery wet tongue into your " + assholeDescript() + ", greedily lapping at your exposed backside as if it were a quickly-melting ice cream cone.  The sensation causes you to groan and grind against the tongue, suddenly lost in ecstasy.  You are surprised at the strength in the demon's neck as he smashes your body against the tree with nothing but his mouth.  You feel his saliva, thick and warm like melted candy, sliding inside of you and coating your insides.");
+				outputText("Looking back you watch Akbal bend low, losing sight of the jaguar demon as he disappears behind you.  For a moment you wonder what he's doing, but soon you feel him shove his face into your [butt] with a snarl.  He begins working his slippery wet tongue into your " + assholeDescript() + ", greedily lapping at your exposed backside as if it were a quickly-melting ice cream cone.  The sensation causes you to groan and grind against the tongue, suddenly lost in ecstasy.  You are surprised at the strength in the demon's neck as he smashes your body against the tree with nothing but his mouth.  You feel his saliva, thick and warm like melted candy, sliding inside of you and coating your insides.");
 				//(If Player has Vagina)
 				if (player.hasVagina())
 					outputText("  Akbal slurps his way down to your " + vaginaDescript(0) + " twisting his face and drilling his tongue into you, mercilessly attacking your " + clitDescript() + " as you scream, howl, and cringe in ecstasy.  He then uses his lips to gently suck your " + clitDescript() + " into his mouth and twirl his tongue on it, making your grind your swollen sex against his jaguar lips.");
@@ -807,27 +809,27 @@ package classes.Scenes.Areas.Forest
 
 				//(Small/Virgin Pucker)
 				//[Small/virgin pucker]
-				if (player.ass.analLooseness < 3) {
+				if (player.ass.analLooseness < AssClass.LOOSENESS_LOOSE) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only insanely large but its head is covered in a dozen tiny barbs.  You grit your teeth, expecting pain and yet, thanks to the weird saliva he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 					outputText("The feeling of being stretched by Akbal's long, slimy member makes you shudder.  The weird spit even heats up which creates a steamy warmth inside you as Akbal's hot member makes your body spasm slightly.  After a few slow, shallow strokes you begin to feel the barbs vibrate.  This vibrating sends your body into convulsions, the wicked-looking barbs feel more like humming sex beads than punishing spikes.  When Akbal picks up the pace you grit your teeth as you are stretched beyond your natural limits.");
 				}
 				//(Medium Pucker)
-				else if (player.ass.analLooseness < 5) {
+				else if (player.ass.analLooseness < AssClass.LOOSENESS_GAPING) {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs.  Yet,  thanks to the weird spit he slathered your innards with, there is none as his gargantuan member forcibly widens your " + assholeDescript() + ".\n\n");
 					outputText("Akbal's titanic member stretches your " + assholeDescript() + " and makes you groan and claw at the tree he has you pressed against, reveling in the slick heat and fullness of your bowels.  His saliva heats up, creating a steamy yet pleasurable warmth inside your body.  As he begins to pump his huge sex organ in and out of you the barbs covering his head begin to vibrate and hit your body with tidal waves of unbearable pleasure, feeling more like vibrating sex beads than punishing spikes.  You lean back into his thrusts as his trunk begins slamming into your [butt] in rhythmic claps that echo throughout the forest.");
 				}
 				//(Gapping Pucker - Remember Akbal's dick is 15 inches)
 				else {
 					outputText("You feel him poking around your " + assholeDescript() + " and quickly realize his member is not only quite large but covered in almost a dozen tiny barbs.  When Akbal begins to penetrate you he groans in surprise as his large dick sinks into your [butt] easily, the sudden invasion causing you to croon.\n\n");
-					outputText("The weird spit he slathered your insides with begins to heat up instantly and the barbs covering his cock head start vibrating.  The sensation is like a dozen small slimy sex beads spinning and shaking as they are pushed inside you.  Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing the tree you're shoved up against to shake back and forth.  You try to meet his deep thrusts but the jaguar fucks you with speed and force befitting a cheetah and the constantly vibrating barbs make your body shiver with each hammer blow to your insides.");
+					outputText("The weird spit he slathered your insides with begins to heat up instantly, and the barbs covering his cock head start vibrating.  The sensation is like a dozen small slimy sex beads spinning and shaking as they are pushed inside you.  Akbal wastes no time and begins forcibly fucking your " + assholeDescript() + " with reckless abandon, his every brutal thrust causing the tree you're shoved up against to shake back and forth.  You try to meet his deep thrusts, but the jaguar fucks you with speed and force befitting a cheetah, and the constantly vibrating barbs make your body shiver with each hammer blow to your insides.");
 				}
 				player.buttChange(monster.cockArea(0), true);
 				outputText("\n\n");
 
 				//(ending)
-				outputText("Akbal works his hips fast, piston-pumping his long demon-cat dick in and out of your " + assholeDescript() + ".  Your body is racked by orgasm after orgasm and soon the ground beneath your pawing hooves is covered in a thick layer of your own love juices.  Then Akbal releases a harsh growl and you feel the large feline member twitching and swelling inside you.  A growl sounds in your own chest as the hot, corrupted seed of the demon cat shoots into you.  The feeling of the hot, wet warmth being fucked deeper into you is so close to supreme bliss you can scarcely tell the difference.\n\n");
+				outputText("Akbal works his hips fast, piston-pumping his long demon-cat dick in and out of your " + assholeDescript() + ".  Your body is racked by orgasm after orgasm and soon the ground beneath your pawing hooves is covered in a thick layer of your own love juices.  Then Akbal releases a harsh growl, and you feel the large feline member twitching and swelling inside you.  A growl sounds in your own chest as the hot, corrupted seed of the demon cat shoots into you.  The feeling of the hot, wet warmth being fucked deeper into you is so close to supreme bliss you can scarcely tell the difference.\n\n");
 
-				outputText("After a few moments you realize Akbal isn't slowing down.  His piston pumping hips drive right through his orgasm and never stop slamming into your [butt].  He continues until he's erupted no less than eight times, masterfully working your hole the entire time.\n\n");
+				outputText("After a few moments, you realize Akbal isn't slowing down.  His piston pumping hips drive right through his orgasm and never stop slamming into your [butt].  He continues until he's erupted no less than eight times, masterfully working your hole the entire time.\n\n");
 
 				outputText("After his last massive eruption you feel the jaguar demon pull out, releasing even more of his copious load from your happy hole in an oddly satisfying cascade of thick white cream that rushes like a waterfall down your legs");
 				if (player.cockTotal() > 0)
@@ -853,7 +855,7 @@ package classes.Scenes.Areas.Forest
 			outputText(images.showImage("akbal-deepwoods-sumbitanal"));
 			outputText("After thinking for a minute, you nod to Akbal.  The deep voice in your head commands you to disrobe.  You obediently take off your [armor] and set it aside just before the demon is upon you.\n\n");
 
-			outputText("Akbal pushes you face-first into the ground and places his forward paws on your back, pinning your chest against the ground.  He removes them after a few seconds and you attempt to reposition yourself, only for you to be pushed back down again: a silent yet forceful command for you to stay in this position.\n\n");
+			outputText("Akbal pushes you face-first into the ground and places his forward paws on your back, pinning your chest against the ground.  He removes them after a few seconds, and you attempt to reposition yourself, only for you to be pushed back down again: a silent yet forceful command for you to stay in this position.\n\n");
 
 			outputText("His paws slide to your waist, changing into hands along the way.  You look back and watch as his body starts morphing into a more humanoid shape, his muscles shifting themselves beneath his skin as his body changes to something better suited to dominate you.\n\n");
 
@@ -872,7 +874,7 @@ package classes.Scenes.Areas.Forest
 
 			outputText("You feel him poking around your " + assholeDescript() + ", learning quickly that not only is his member insanely large, but its head is covered in dozens of tiny barbs.  ");
 			//[Small/virgin pucker]
-			if (player.ass.analLooseness < 3) {
+			if (player.ass.analLooseness < AssClass.LOOSENESS_LOOSE) {
 				outputText("You grit your teeth, expecting pain. However, thanks to the weird saliva he slathered your innards with, you feel none as his gargantuan member forcibly widens your " + assholeDescript() + ".");
 				player.buttChange(monster.cockArea(0), true);
 				outputText("\n\n");
@@ -880,7 +882,7 @@ package classes.Scenes.Areas.Forest
 				outputText("Being stretched by Akbal's long and slick member makes you shudder. The weird spit even begins to heat up, creating a steamy warmth inside you as Akbal's equally hot member stretches you out, your body spasming slightly in response.  After a few slow and shallow strokes, you can feel the barbs begin to vibrate.  The sudden motion sends your body into convulsions, the wicked-looking barbs acting more like humming sex beads than barbs.  When Akbal picks up the pace, you can only grit your teeth harder as you're stretched more and more beyond your natural limits.\n\n");
 			}
 			//[Medium Pucker]
-			else if (player.ass.analLooseness < 5) {
+			else if (player.ass.analLooseness < AssClass.LOOSENESS_GAPING) {
 				outputText("Thanks to the weird saliva he slathered your innards with, you feel no pain as his gargantuan member forcibly widens your " + assholeDescript() + ".");
 				player.buttChange(monster.cockArea(0), true);
 				outputText("\n\n");
@@ -901,7 +903,7 @@ package classes.Scenes.Areas.Forest
 				outputText("in sexual bliss");
 			outputText(".\n\n");
 
-			outputText("Akbal releases a harsh growl and you feel his large feline member twitch and swell inside you.  You let out a growl of your own as the hot, corrupted seed of the demon cat shoots into you.  Feeling the hot, wet warmth being fucked deeper into you is so close to supreme bliss that you can scarcely tell the difference.\n\n");
+			outputText("Akbal releases a harsh growl, and you feel his large feline member twitch and swell inside you.  You let out a growl of your own as the hot, corrupted seed of the demon cat shoots into you.  Feeling the hot, wet warmth being fucked deeper into you is so close to supreme bliss that you can scarcely tell the difference.\n\n");
 
 			outputText("After the sensation begins to settle, you realize Akbal isn't slowing down.  His hips carry on with their pistoning right through his orgasm and continually slam into your [butt].  He persists until he's erupted no less than eight times, masterfully working your hole the entire time.\n\n");
 
@@ -932,17 +934,17 @@ package classes.Scenes.Areas.Forest
 			if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] < 4) {
 				outputText("You awake in your camp feeling dangerous, powerful and fiercely satisfied.");
 			}
-				//[After 8th submission, if whispered and corruption is greater than 80%]
+			//[After 8th submission, if whispered and corruption is greater than 80%]
 			//(fighting Akbal disables this scene, but you retain the ability if you rape him after)
-			else if (flags[kFLAGS.PLAYER_RESISTED_AKBAL] == 0 && flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] >= 8 && player.cor > 80) {
-				if (player.cor < 80 || player.hasPerk(PerkLib.FireLord)) {
+			else if (flags[kFLAGS.AKBAL_SUBMISSION_COUNTER] >= 8 && player.cor > 80) {
+				if (player.hasPerk(PerkLib.FireLord)) {
 					outputText("You awake in your camp feeling dangerous, powerful and fiercely satisfied.");
 				}
 				else {
-					outputText("You open your eyes and almost yell in surprise when you see Akbal's emerald eyes looking into yours.  You are still in the forest and his lithe jaguar body is still over you; you quickly realize he hasn't moved you, as you're still resting in a puddle of mixed sex juices.\n\n");
+					outputText("You open your eyes and almost yell in surprise when you see Akbal's emerald eyes looking into yours.  You are still in the forest, and his lithe jaguar body is still over you; you quickly realize he hasn't moved you, as you're still resting in a puddle of mixed sex juices.\n\n");
 					outputText("\"<i>You are a loyal pet,</i>\" Akbal says as he stands. The compliment makes you smile, but it quickly fades into a look of fear when he suddenly releases a bone-chilling roar right in your face.  Green flames begin to pour from his open maw, and you scream as you flail your hands in a pointless attempt to block the fire.\n\n");
 					outputText("After a moment of horror, you realize you aren't burning.  You can feel the emerald flames inside your lungs, glowing with a palpable warmth.  Akbal snaps his teeth together, a feral grin on his face as he halts the torrent of flame.\n\n");
-					outputText("You can feel Akbal's demonic presence inside your lungs, slowly building up until it finally explodes out of your open mouth in a titanic roar, accompanied with a jet of emerald flame.\n\n");
+					outputText("You can feel Akbal's demonic presence inside your lungs, slowly building up until it finally explodes out of your open mouth in a titanic roar, accompanied by a jet of emerald flame.\n\n");
 					outputText("<b>(You are now capable of breathing Akbal's fire!)</b>");
 					//['LOTF' or 'Terrestrial Fire Lord' appears as perk]
 					//[Gain 'Terrestrial Fire' in Specials]
@@ -964,18 +966,6 @@ package classes.Scenes.Areas.Forest
 			doNext(playerMenu);
 		}
 
-		/*
-		   [Items]
-		   [Jaguar Pelt]
-		   The pelt of a Jaguar demon.  It's surprisingly durable and flexible.
-		   (maybe have the alchemist or that shop guy offer to turn it into armor)
-
-		   [Demon Jaguar Cloak]
-		   Def + 2
-		   Speed +10
-		   Evasion+5
-		 */
-
 		private function akbalBigButtSubmit():void {
 			clearOutput();
 			outputText(images.showImage("akbal-deepwoods-bigbuttanaled"));
@@ -987,7 +977,7 @@ package classes.Scenes.Areas.Forest
 			else if (player.hasVagina())
 				outputText(" and [vagina]");
 			outputText(".  You cannot help but squirm from the attention, feeling the slippery-hot length of his muscle probing your sensitive ring.  In its wake, the panther's flexible tongue leaves behind copious amounts of his slick saliva that makes your skin tingle pleasantly.  You don't have long to wonder at this as he broadens his roving attentions to slather each of your cheeks with love, licking and lapping over your " + player.skinFurScales() + " in what could only be described as worship.  A tremor of gleeful pride works through your mind - your master approves of his servant's body!");
-			outputText("\n\nWith your ass in the air, you pant in relaxed pleasure, allowing Akbal to work your [butt] into a glorious shine.  Only after every inch of your pillowy derriere has been slathered with panther-spit does he return to his real intent, spreading your cheeks wide to expose your saliva-glossed asshole.  Your pucker twitches hungrily, tingling from your god's perverse fluids, sensitive and desirous of affection.  He does not deny your body's unspoken request, and the long, wriggling tongue slides through, twisting into your back door to deck your interior with more of his lovely juices.  You cannot help but moan at this - it feels better than it should, like a hot, slippery massage for your insides.");
+			outputText("\n\nWith your ass in the air, you pant in relaxed pleasure, allowing Akbal to work your [butt] into a glorious shine.  Only after every inch of your pillowy derrière has been slathered with panther-spit does he return to his real intent, spreading your cheeks wide to expose your saliva-glossed asshole.  Your pucker twitches hungrily, tingling from your god's perverse fluids, sensitive and desirous of affection.  He does not deny your body's unspoken request, and the long, wriggling tongue slides through, twisting into your back door to deck your interior with more of his lovely juices.  You cannot help but moan at this - it feels better than it should, like a hot, slippery massage for your insides.");
 			if (player.hasCock())
 				outputText("  Bobbing beneath you, [eachCock] makes no secret of how much you're enjoying this, with thin drops of pre-cum dangling precariously below.");
 			else if (player.hasVagina())
@@ -1050,10 +1040,9 @@ package classes.Scenes.Areas.Forest
 		//2. AKBAL'S MY BITCH
 		//By Foxxling
 		//Akbal’s My Bitch Expansion
-		//Auto Rape Intro Scene
 		private function akbitchEncounter():void {
 			clearOutput();
-			outputText("As you explore the deep woods you begin to hear a soft slurping sound. In this world you know that any strange sound, especially the wet ones, most likely means something dangerous is up ahead... or something dangerous is fucking something a little less dangerous.  As you cautiously advance you spy the pelt of the jaguar demon, Akbal.  The demon jaguar sits in the middle of the clearing with one leg extended as he repeatedly swipes his wide tongue against his hole, probably cleaning up imp spunk thanks to you.  He is so utterly focused on the task that he doesn’t notice your approach.");
+			outputText("As you explore the deep woods, you begin to hear a soft slurping sound. In this world you know that any strange sound, especially the wet ones, most likely means something dangerous is up ahead... or something dangerous is fucking something a little less dangerous.  As you cautiously advance you spy the pelt of the jaguar demon, Akbal.  The demon jaguar sits in the middle of the clearing with one leg extended as he repeatedly swipes his wide tongue against his hole, probably cleaning up imp spunk thanks to you.  He is so utterly focused on the task that he doesn’t notice your approach.");
 			flags[kFLAGS.AKBAL_BITCH_Q] = 1;
 			if ((player.cor < 40 + player.corruptionTolerance && !player.hasPerk(PerkLib.Pervert) && !player.hasPerk(PerkLib.Sadist)) || player.lust < 33) {
 				sceneHunter.print("Check failed: (high corruption or Pervert/Sadist perk) + high lust")

--- a/classes/classes/Scenes/Areas/Forest/Alraune.as
+++ b/classes/classes/Scenes/Areas/Forest/Alraune.as
@@ -10,7 +10,6 @@ import classes.BodyParts.Hips;
 import classes.BodyParts.LowerBody;
 import classes.Scenes.Holidays;
 import classes.Scenes.SceneLib;
-import classes.internals.ChainedDrop;
 import classes.display.SpriteDb;
 import classes.internals.WeightedDrop;
 

--- a/classes/classes/Scenes/Areas/Forest/AlrauneMaiden.as
+++ b/classes/classes/Scenes/Areas/Forest/AlrauneMaiden.as
@@ -5,8 +5,6 @@
 package classes.Scenes.Areas.Forest 
 {
 import classes.*;
-import classes.GlobalFlags.*;
-import classes.Scenes.Areas.Forest.Alraune;
 import classes.Scenes.Holidays;
 import classes.internals.ChainedDrop;
 

--- a/classes/classes/Scenes/Areas/Forest/AlrauneScene.as
+++ b/classes/classes/Scenes/Areas/Forest/AlrauneScene.as
@@ -6,7 +6,6 @@ package classes.Scenes.Areas.Forest
 {
 	import classes.*;
 	import classes.GlobalFlags.kFLAGS;
-	import classes.CoC;
 	import classes.Scenes.Areas.Tundra.SnowLily;
 	import classes.Scenes.Areas.Ashlands.Cinderbloom;
     import classes.display.SpriteDb;
@@ -25,7 +24,7 @@ public class AlrauneScene extends BaseContent
 			if(player.isLiliraune())
 			{
 				outputText("You and your sister look at each other, then shrug before replying." +
-						"\"<i>Looking for a stamen to fertilize us or a pussy to stuff our seed, truly.</i>\"\n\n" +
+						"\"<i>Looking for a stamen to fertilize us, or a pussy to stuff our seed, truly.</i>\"\n\n" +
 						"\"<i>Except we haven’t found anyone but you so far.</i>\"\n\n");
 			}
 			outputText("You pretty much stumbled upon her at random though truth be told now that you think of it there is no such thing as incest when it comes down to plants.");
@@ -42,8 +41,8 @@ public class AlrauneScene extends BaseContent
 					"Truth be told, if a penis had grown to ridiculous length and gained this kind of absurd flexibility, " +
 					"it would have felt similar to getting a handjob and giving someone a handjob at the same time as one of your vines coil and slide on " +
 					"the other plant girl’s vines, both stamen pointing toward the sky as you moan in delight. " +
-					"You both swiftly reach a first orgasm and the two entwined vines rain pollen in the area. " +
-					"That's only one stamen out of many however and you reposition your vines so that each tip is aligned toward your partner’s cunt, " +
+					"You both swiftly reach a first orgasm, and the two entwined vines rain pollen in the area. " +
+					"That's only one stamen out of many however, and you reposition your vines so that each tip is aligned toward your partner’s cunt, " +
 					"entwining all of your other vines around the first two to create what could be only called a vine made double ended dildo. " +
 					"The smell of her stamens is overpowering your senses and without a second thought you shove all of her 10 appendages together in your pussy just as you feel the end of your vines being pulled inside her wet fold. " +
 					"Your eyes roll in absolute bliss as all of your vine lengths are sliding on each other, all of your stamen fucking a wanting pussy at the same time as your own plant cunt is being filled up. " +
@@ -63,12 +62,12 @@ public class AlrauneScene extends BaseContent
 			AlrauneVSAlraune("forest","alraune");
 		} else {
 			if (isHalloween()) {
-				outputText("As you wander the area you come across a rather large pumpkin growing in the forest. You ponder how plants even manage to grow this big to begin with. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the pumpkin as it opens up, revealing a beautiful woman with pale orange skin and light green eyes.\n\n");
-				outputText("\"<i>Boo!!! Trick or treat?! Well you don’t seem very keen on giving me treats so I guess I will have to collect.</i>\"\n\n");
+				outputText("As you wander the area, you come across a rather large pumpkin growing in the forest. You ponder how plants even manage to grow this big to begin with. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the pumpkin as it opens up, revealing a beautiful woman with pale orange skin and light green eyes.\n\n");
+				outputText("\"<i>Boo!!! Trick or treat?! Well you don’t seem very keen on giving me treats, so I guess I will have to collect.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			}
 			else {
-				outputText("As you wander the forest you come across a rather large flower, easily twice your size. You ponder how plants even manage to grow this big even on Mareth. The flower has pink petals and a pitcher like center. While you are busy examining it, several large vines surge out at you, binding your arms and legs and reeling you toward the flower as it opens up, revealing a beautiful woman with light green skin and deep green eyes.\n\n");
+				outputText("As you wander the forest you come across a rather large flower, easily twice your size. You ponder how plants even manage to grow this big even on Mareth. The flower has pink petals and a pitcher-like center. While you are busy examining it, several large vines surge out at you, binding your arms and legs and reeling you toward the flower as it opens up, revealing a beautiful woman with light green skin and deep green eyes.\n\n");
 				outputText("\"<i>Mmmmmm such a nice catch... Come closer into my pitcher.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			}
@@ -87,11 +86,11 @@ public class AlrauneScene extends BaseContent
 			AlrauneVSAlraune("crag","cinderbloom");
 		} else {
 			if (isHalloween()) {
-				outputText("As you wander the area you come across a rather large pumpkin growing in the ashlands. You ponder how plants even manage to grow this big to begin with. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the pumpkin as it opens up, revealing a beautiful woman with pale orange skin and light green eyes.\n\n");
-				outputText("\"<i>Boo!!! Trick or treat?! Well you don’t seem very keen on giving me treats so I guess I will have to collect.</i>\"\n\n");
+				outputText("As you wander the area, you come across a rather large pumpkin growing in the ashlands. You ponder how plants even manage to grow this big to begin with. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the pumpkin as it opens up, revealing a beautiful woman with pale orange skin and light green eyes.\n\n");
+				outputText("\"<i>Boo!!! Trick or treat?! Well you don’t seem very keen on giving me treats, so I guess I will have to collect.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			} else {
-				outputText("As you wander the ashlands you come across a rather large flower growing in the ashes. You ponder how plants even manage to grow in this inhospitable landscape. The flower has petals the same color as lava and a pitcher like center. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the flower as it opens up, revealing a beautiful woman with chocolate skin and deep red eyes.\n\n");
+				outputText("As you wander the ashlands, you come across a rather large flower growing in the ashes. You ponder how plants even manage to grow in this inhospitable landscape. The flower has petals the same color as lava, and a pitcher like center. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the flower as it opens up, revealing a beautiful woman with chocolate skin and deep red eyes.\n\n");
 				outputText("\"<i>Mmmmmm such a nice catch... Come closer into my pitcher.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			}
@@ -106,11 +105,11 @@ public class AlrauneScene extends BaseContent
 			AlrauneVSAlraune("rift","snow lily");
 		} else {
 			if (isHalloween()) {
-				outputText("As you wander the area you come across a rather large pumpkin growing in the tundra. You ponder how plants even manage to grow this big to begin with. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the pumpkin as it opens up, revealing a beautiful woman with pale orange skin and light green eyes.\n\n");
-				outputText("\"<i>Boo!!! Trick or treat?! Well you don’t seem very keen on giving me treats so I guess I will have to collect.</i>\"\n\n");
+				outputText("As you wander the area, you come across a rather large pumpkin growing in the tundra. You ponder how plants even manage to grow this big to begin with. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the pumpkin as it opens up, revealing a beautiful woman with pale orange skin and light green eyes.\n\n");
+				outputText("\"<i>Boo!!! Trick or treat?! Well you don’t seem very keen on giving me treats, so I guess I will have to collect.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			} else {
-				outputText("As you wander the  tundra you come across a rather large flower growing in the snow. You ponder how plants even manage to grow in this cold landscape. The flower has petals the same color as the snow and a pitcher like center. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the flower as it opens up, revealing a beautiful woman with sky blue skin and light blue eyes.\n\n");
+				outputText("As you wander the tundra, you come across a rather large flower growing in the snow. You ponder how plants even manage to grow in this cold landscape. The flower has petals the same color as the snow and a pitcher like center. While you are busy examining it, large vines surge out at you, binding your arms and legs and reeling you toward the flower as it opens up, revealing a beautiful woman with sky blue skin and light blue eyes.\n\n");
 				outputText("\"<i>Mmmmmm such a nice catch... Come closer into my pitcher.</i>\"\n\n");
 				outputText("There's no way you will let this thing pull you in!\n\n");
 			}
@@ -119,49 +118,37 @@ public class AlrauneScene extends BaseContent
 	}
 	
 	public function alrauneDeepwoodsWon():void {
-		if (monster.short == "cinderbloom alraune") spriteSelect(SpriteDb.s_cinderbloom);
-		else if (monster.short == "snow lily alraune") spriteSelect(SpriteDb.s_snow_lily);
-		else if (isHalloween()) spriteSelect(SpriteDb.s_alraune);
-		else spriteSelect(SpriteDb.s_alraune);
 		clearOutput();
-		if (isHalloween()) outputText("The Jack-O-Raune, unable to fight any longer, retreat in her pumpkin in self defence, her vines unwrapping from you. Well, you are free, but the god damn plant woman left you horny and frustrated, what a tease! Guess it's time to head back to camp.\n\n");
-		else outputText("The alraune, unable to fight any longer, closes her petals in self defence, her vines unwrapping from you. Well, you are free, but the god damn plant woman left you horny and frustrated, what a tease! Guess it's time to head back to camp.\n\n");
+		if (isHalloween()) outputText("The Jack-O-Raune, unable to fight any longer, retreat in her pumpkin in self defence, her vines unwrapping from you. Well, you are free, but the god-damn plant woman left you horny and frustrated, what a tease! Guess it's time to head back to camp.\n\n");
+		else outputText("The alraune, unable to fight any longer, closes her petals in self defence, her vines unwrapping from you. Well, you are free, but the god-damn plant woman left you horny and frustrated, what a tease! Guess it's time to head back to camp.\n\n");
 		cleanupAfterCombat();
 	}
 	
 	public function alrauneDeepwoodsLost():void {
-		if (monster.short == "cinderbloom alraune") spriteSelect(SpriteDb.s_cinderbloom);
-		else if (monster.short == "snow lily alraune") spriteSelect(SpriteDb.s_snow_lily);
-		else if (isHalloween()) spriteSelect(SpriteDb.s_alraune);
-		else spriteSelect(SpriteDb.s_alraune);
 		clearOutput();
-		if (player.gender == 1) {
-			if (monster.statusEffectv1(StatusEffects.Level) > 2) outputText("Your desire finally breaks your resolve as you stop struggling and make a dopey lust drunk face while the vines bring you to their mistress. ");
-			outputText("You don’t recall when or how you ended up in her nectar bath, but there you are and your cock is throbbing with burning desire for this female.\n\n");
+		if (monster.statusEffectv1(StatusEffects.Level) > 2) outputText("Your desire finally breaks your resolve as you stop struggling and make a dopey lust drunk face while the vines bring you to their mistress. ");
+		if (player.gender == 1 && (!sceneHunter.uniHerms || rand(2) == 0)) {
+			outputText("You don’t recall when or how you ended up in her nectar bath, but there you are, and your cock is throbbing with burning desire for this female.\n\n");
 			outputText("\"<i>Aw you poor thing. Let me comfort this pained stamen of yours with my nectar gushing pussy.</i>\"\n\n");
-			outputText("She begins to run her hands all over your body, making you shiver at the touch. She grabs you by the shoulders and brings you closer to her as she begins to kiss you, her sweet nectar flowing from her mouth to yours. It tastes wonderful yet is packed with powerful aphrodisiac; so before you know it your desire to mate intensifies and your cock is now aching to be used. You begin to drool mindlessly as her hands caress your throbbing cock.\n\n");
+			outputText("She begins to run her hands all over your body, making you shiver at the touch. She grabs you by the shoulders and brings you closer to her as she begins to kiss you, her sweet nectar flowing from her mouth to yours. It tastes wonderful yet is packed with powerful aphrodisiac; so before you know it your desire to mate intensifies, and your cock is now aching to be used. You begin to drool mindlessly as her hands caress your throbbing cock.\n\n");
 			outputText("\"<i>Mmmm you look about ready... such a nice face you're making, it makes me even more wet for you.</i>\"\n\n");
 			outputText("Her pussy is like a balm on your suffering cock, as her nectar slowly coats your entire length, you feel your manhood tingle with the telltale pleasure of more aphrodisiac entering your body. Your twitching balls, which have been dipped in the syrup for god knows how long, have grown so large you could compete with a pussy starved minotaur and your dick... oh your dick! The feeling of her pussy wrapped around your cock is so perfect you almost melt in her arms.\n\n");
 			outputText("\"<i>Just stay still, honey, while I take care of you.</i>\"\n\n");
 			outputText("She wraps some of her vines around you both, using them to pull you both closer as she slides on your cock. You moan in incomprehensible babble as your drugged penis is milked by the alraune, cum flooding out at about a rate as steady as her pussy nectar. Men can, normally, only orgasm once or twice before they need a rest; you however simply can’t lose your hard on, cumming over and over as your drugged balls keep producing an almost endless amount of semen. ");
 			outputText("Whenever the Alraune sees the signs of thirst on your face, she quenches it with her breast, filling your mouth with more nectar. Go figure because plants don't leak any other fluids than that. Thankfully your stamina eventually gives out as you fall unconscious, way before your raging erection dies out.\n\n");
-			outputText("When you wake up you are in a different area with your gear packed up next to you. Seems some thief made off with a small amount of your gems though.\n\n");
+			outputText("When you wake up, you are in a different area with your gear packed up next to you. Seems some thief made off with a small amount of your gems though.\n\n");
 			player.sexReward("vaginalFluids","Dick")
 		}
 		else {
-			if (monster.statusEffectv1(StatusEffects.Level) > 2) outputText("Your desire finally breaks your resolve as you stop struggling and make a dopey lust drunk face while the vines bring you to their mistress. ");
-			outputText("You don’t recall when or how you ended up naked in her nectar bath but there you are, fawning in the arms of the ");
-			if (isHalloween()) outputText("pumpkin");
-			else outputText("plant");
-			outputText(" woman.\n\n");
-			outputText("\"<i>Mmmmm aren’t you a eager girl? Let’s start at the beginning then.</i>\"\n\n");
+			outputText("You don’t recall when or how you ended up naked in her nectar bath but there you are, fawning in the arms of the " + (isHalloween() ? "pumpkin" : "plant") + " woman.\n\n");
+			outputText("\"<i>Mmmmm aren’t you an eager girl? Let’s start at the beginning then.</i>\"\n\n");
 			outputText("She begins to run her hands all over your body, making you shiver at every touch. She grabs you by the shoulders and brings you closer to her as she begins to kiss you, her sweet nectar flowing into your mouth. It tastes wonderful yet is packed with a powerful aphrodisiac. Before you know it, your desire for her only skyrockets. You break the kiss, a thin strand of syrupy nectar still connecting your lips as she moves a hand to your breasts, ");
-			outputText("cupping them up, as she picks up some nectar with her other hand and pours it on your body making you all sticky with her lovely nectar. Your skin begins to tingle as it soaks in the aphrodisiacs in her nectar and you gasp as a small breeze blows past you.\n\n");
+			outputText("cupping them up, as she picks up some nectar with her other hand and pours it on your body making you all sticky with her lovely nectar. Your skin begins to tingle as it soaks in the aphrodisiacs in her nectar, and you gasp as a small breeze blows past you.\n\n");
 			outputText("\"<i>Umm... you should find my touch to be way more delectable now.</i>\"\n\n");
 			if (isHalloween()) outputText("Jack-O-Raune");
 			else outputText("The alraune");
 			outputText(" gently moves her head to your nipples and begins suckling, making you moan as a whole new world of pleasure opens to you. She gently suckles on your breast for a few moments until you're unable to stand from the massive pleasure overload rocking your body. This is too much! ");
-			outputText("You want to be touched by her, kissed by her and most of all your drug addled mind wants her to fuck your pleasure-starved pussy. The ");
+			outputText("You want to be touched by her, kissed by her, and most of all your drug addled mind wants her to fuck your pleasure-starved pussy. The ");
 			if (isHalloween()) outputText("pumpkin");
 			else outputText("plant");
 			outputText(" girl caresses your breast making your pussy gush as she slowly gets you in position sitting in her bath.\n\n");
@@ -170,7 +157,7 @@ public class AlrauneScene extends BaseContent
 			outputText("\"<i>Hang on tightly to me... we’re beginning.</i>\"\n\n");
 			outputText("Her stamen bulbs open inside of your cunt and ass and your eyes go wide as you are struck by yet another orgasm. She begins to wildly fuck you, your mouth drooling and your eyes rolling back as you lose the ability to make coherent words. She fills you over and over with her liquid pollen, making your belly swell to the size of a heavily pregnant woman as you buck your hips mindlessly. ");
 			outputText("You barely recall her gently lifting you out of her bath and depositing you to the ground as you lose consciousness.\n\n");
-			outputText("When you wake up you are in a different area with your gear packed up next to you. Seems some thief made off with a small amount of your gems though.\n\n");
+			outputText("When you wake up, you are in a different area with your gear packed up next to you. Seems some thief made off with a small amount of your gems though.\n\n");
 			if (player.hasUniquePregnancy()) player.impregnationRacialCheck();
             else player.knockUp(PregnancyStore.PREGNANCY_ALRAUNE, PregnancyStore.INCUBATION_ALRAUNE);
 			player.sexReward("cum", "Vaginal");

--- a/classes/classes/Scenes/Areas/Forest/BeeGirlScene.as
+++ b/classes/classes/Scenes/Areas/Forest/BeeGirlScene.as
@@ -72,7 +72,7 @@ public class BeeGirlScene extends BaseContent
 		private function beeEncounterSelect(clearScreen:Boolean = true):void {
 			if (clearScreen) clearOutput();
 			spriteSelect(SpriteDb.s_bee_girl);
-			outputText("That's when she comes into view.  A great woman, yellow and black, a Bee-like handmaiden would be the best comparison.  She sits atop a great flower while humming her tune, happily picking the petals off of another flower.  Her body is thin, save her abdomen.  Her head is more humanoid than bee, with black eyes, floppy antennae, and luscious black lips that glimmer wetly");
+			outputText("That's when she comes into view.  A great woman, yellow and black, a Bee-like handmaiden would be the best comparison.  She sits atop a great flower while humming her tune, happily picking the petals off of another flower.  Her body is thin, save her abdomen.  Her head is more humanoid than bee, with black eyes, floppy antennae, and luscious black lips that glimmer wetly.");
 			//Alraune race
 			if (player.lowerBody == LowerBody.PLANT_FLOWER) {
 				AlrauneAndBee();

--- a/classes/classes/Scenes/Areas/Forest/Faerie.as
+++ b/classes/classes/Scenes/Areas/Forest/Faerie.as
@@ -32,7 +32,7 @@ public function encounterFaerie():void {
 			else if(player.statusEffectv1(StatusEffects.FaerieFucked) < 15) {
 				outputText("\n\nYou grasp the dizzy faerie out of the air with ease, smiling as you feel the flood of wetness between her thighs moistening your hand.  She wriggles and moans, \"<i>No, not again!  I want another cum-bath so bad... but I'm losing myself to it.  It's hard to keep flowers pollinated when you're jilling off half the day and waiting for a nice hard cock to wander your way...</i>\"\n\nShe wants to get you off almost as you do.  Do you make her service you again?");
 			}
-			else outputText("\n\nYou lazily make a grab for her and easily snatch her out of the air.  Her body is sticky with a mix of desire and your last encounter.  You can feel her humping against your pinky while she begs, \"<i>Come on, let me crawl into your [armor] and wrap myself around your shaft.  I promise I'll only drink a little pre-cum this time, just enough to let me get off.  I'll be a good faerie slut, just let me get you off!</i>\"\n\nDo you let the faerie get you off?");
+			else outputText("\n\nYou lazily make a grab for her and easily snatch her out of the air.  Her body is sticky with a mix of desire and cum from your last encounter.  You can feel her humping against your pinky while she begs, \"<i>Come on, let me crawl into your [armor] and wrap myself around your shaft.  I promise I'll only drink a little pre-cum this time, just enough to let me get off.  I'll be a good faerie slut, just let me get you off!</i>\"\n\nDo you let the faerie get you off?");
 			dynStats("lus", player.lib/10+2);
 			doYesNo(faerieCaptureHJ, letFaerieGo);
 			if(player.statusEffectv1(StatusEffects.FaerieFucked) < 5) addButton(2, "Never", disableFaerieEncounterForGood);
@@ -43,7 +43,7 @@ public function encounterFaerie():void {
 			outputText("\n\nYou groan miserably with frustration. Desperate for stimulation, you sink to your knees and start jacking off, the faerie's visage still fresh in your mind. You catch a fleeting glimpse of yourself tightly gripping the faerie's legs in each of your fists, dragging her toward ");
 			if(player.cockTotal() == 1) outputText("your dick");
 			else outputText("one of your dicks");
-			outputText(", too large for her tiny frame... the depraved image overwhelms your mind's eye and you find yourself shooting all over the ground furiously.");
+			outputText(", too large for her tiny frame... the depraved image overwhelms your mind's eye, and you find yourself shooting all over the ground furiously.");
 			player.orgasm();
 		}
 		else outputText("\n\nYou try in vain to jump and catch her, but she's too high above you and much too fast.");
@@ -53,8 +53,10 @@ public function encounterFaerie():void {
 	outputText("The faerie slows the beating of her wings and hovers towards you. You dismiss your fearful notions, certain a small faerie is quite harmless to you.\n\n");
 	outputText("How do you react?");
 	//Shoo Away, Nothing, RAEP
-	if (player.hasVagina()) simpleChoices("Shoo Away", faerieShooAway, "Nothing", faerieDoNothing, "Rape", faerieRAEP, "", null, "", null);
-	else simpleChoices("Shoo Away", faerieShooAway, "Nothing", faerieDoNothing, "", null, "", null, "", null);
+	menu();
+	addButton(0, "Shoo Away", faerieShooAway);
+	addButton(1, "Nothing", faerieDoNothing);
+	addButtonIfTrue(2, "Rape", faerieRAEP, "Req. a vagina", player.hasVagina());
 }
 
 private function faerieRAEP():void {
@@ -71,8 +73,9 @@ private function faerieRAEP():void {
 	else outputText("She squeals, rocking her hips back against you and moaning, \"<i>Ohhhh I love it when you do that,</i>\" grinding her incredibly small love-button on your digit.");
 	//Special Taurness
 	if(player.isTaur()) {
-		outputText("\n\nYou bop the tiny Faerie on the head to daze her briefly, then place her on a branch. You back yourself up against the tiny creature, lifting your tail so she can see your " + vaginaDescript(0) + ". The scent washes toward her and you hear a high pitched giggle; evidently that was more than enough to give her quite the contact high.  You feel a strange sensation in your slit as she slides her legs inside you and wraps her arms around your " + clitDescript() + ".\n\n");
+		outputText("\n\nYou bop the tiny Faerie on the head to daze her briefly, then place her on a branch. You back yourself up against the tiny creature, lifting your tail, so she can see your " + vaginaDescript(0) + ". The scent washes toward her, and you hear a high-pitched giggle; evidently that was more than enough to give her quite the contact high.  You feel a strange sensation in your slit as she slides her legs inside you and wraps her arms around your " + clitDescript() + ".\n\n");
 
+		sceneHunter.print("Fork for clit sizes - 3\"");
 		//[If cock-like clit:
 		if(player.clitLength >= 3) {
 			outputText("The tiny fae begins jerking your clit like a cock, squeezing her arms tightly around you and sliding in and out of your " + vaginaDescript(0) + ". Her motions are frenetic and unpredictable, but incredibly pleasurable.  She starts licking at your " + clitDescript() + " as your femcum runs down it, which only serves to make her more excited. She gets so excited that her legs start kicking wildly as she screams \"<i>Swim! Swim! Swim! Swim!</i>\" over and over again.  ");
@@ -91,11 +94,12 @@ private function faerieRAEP():void {
 			//[Normal amount of cum:
 			else if(player.vaginas[0].vaginalWetness <= VaginaClass.WETNESS_DROOLING) outputText("You cum suddenly, and wetly. The fae giggles more and more as the fluid squirts around her and your " + vaginaDescript(0) + " ripples. Her giggles quickly become all-out laughter, and she loses her grip on your innards, sprawling to the ground into a puddle of femcum.\n\n");
 			//[Huge amount of cum:
-			else outputText("You cum suddenly, and wetly. The fae tries desperately to hold on to your " + clitDescript() + " but the amount of fluid overwhelms her and she's sent spiralling to the ground into a huge puddle of your fluid, her giggling frame floating on the surface as her legs kick about erratically.\n\n");
+			else outputText("You cum suddenly, and wetly. The fae tries desperately to hold on to your " + clitDescript() + " but the amount of fluid overwhelms her, and she's sent spiralling to the ground into a huge puddle of your fluid, her giggling frame floating on the surface as her legs kick about erratically.\n\n");
 		}
 	}
 	//Non-Taurs
 	else {
+		sceneHunter.print("Check failed: taur body");
 		outputText("\n\nYou release the lower portion of your [armor], revealing your aroused slit to the faerie.  ");
 		if(player.statusEffectv1(StatusEffects.FaerieFemFuck) < 4) outputText("Her mood immediately shifts from panic to desire, and she licks her lips hungrily, locking her eyes onto your feminine folds.");
 		else outputText("Her eyes open wide, like a junkie seeing a fix.  She licks her lips hungrily and humps the inside of your hand, ready for action.");
@@ -106,6 +110,7 @@ private function faerieRAEP():void {
 		else outputText("feeling yourself moistening with need");
 		outputText(" from the tiny touches.\n\n");
 
+		sceneHunter.print("Fork for clit sizes - 0.5\", 1.25\" and 4.5\"");
 		//(small) <= .50\"
 		if(player.clitLength <= .5) {
 			outputText("She pulls apart your lips, revealing your tiny bud and repositioning herself to plant her feet inside you.  The flawless skin of her thighs pulls another gasp of pleasure from your lips.  They squeeze tightly around your " + clitDescript() + ", scissoring her gash across its sensitive surface.   You squirm, too engrossed in the rough grinding your button is receiving to worry about the faerie.   She clings to you, hanging on for dear life as your crotch nearly throws her free.  During the gyrations, she's slammed back into the " + clitDescript() + ", instantly penetrated by the nub with a wet 'schlick'.\n\n");
@@ -114,18 +119,18 @@ private function faerieRAEP():void {
 		//(medium) <= .1.25\"
 		else if(player.clitLength <= 1.25) {
 			outputText("She watches, entranced as your " + clitDescript() + " hardens, poking between your lips, flushed with blood like a tiny cock.   The faerie swivels around, planting her dainty butt squarely on your snatch, sinking down a bit into the folds as she wraps her legs around the pulsating 'shaft'.   She hugs it, pressing it between her tiny breasts and licking it up and down, making you moan and squirm from unexpected stimulation of your most sensitive area.\n\n");
-			outputText("You spread your [legs], careful not to dislodge the faerie as she releases the " + clitDescript() + " and stands up, placing her dripping gash against the tip.   A quick plunge later and she's bottomed out, pressing her hips into the opening of your " + vaginaDescript(0) + " her feet slipping over the outer folds as she tries to maintain her balance.   You start rocking back and forth happily, bouncing the faerie up and down.  She moans, cute and barely audible, but sexy in a way that makes your sopping fuckhole even wetter.\n\n");
+			outputText("You spread your [legs], careful not to dislodge the faerie as she releases the " + clitDescript() + " and stands up, placing her dripping gash against the tip.   A quick plunge later, and she's bottomed out, pressing her hips into the opening of your " + vaginaDescript(0) + " her feet slipping over the outer folds as she tries to maintain her balance.   You start rocking back and forth happily, bouncing the faerie up and down.  She moans, cute and barely audible, but sexy in a way that makes your sopping fuckhole even wetter.\n\n");
 			outputText("She orgasms on you, squirting copiously, drenching your " + clitDescript() + " and " + vaginaDescript(0) + " in clear faerie-fluid.  It tingles, wicking into your button and soaking into your snatch, enhancing every sensation.  You can feel the cool forest air as it flows over your vulva, seeming to stroke you, and without any chance of holding yourself back, you plunge your fingers into your " + vaginaDescript(0) + ", immediately orgasming from the penetration, not even noticing the exhausted faerie sliding off the large clit and slipping partway into your cunt.\n\n");
 		}
 		//(streeeetch – large) <= 4.5\"
 		else if(player.clitLength <= 4.5) {
 			outputText("Entranced by the growing " + clitDescript() + ", the faerie caresses her body, watching your love-button swell up, not stopping until it looks too huge for her tiny frame.  She climbs in a circle around it, awestruck by the size and majesty of your cock-like button.    She looks up at you, aroused but worried, saying, \"<i>You're so... BIG.  Oh goddess, I want to feel it inside me!</i>\"\n\n");
 			outputText("She grabs hold of its slippery surface with both hands and jumps, lifting her lower body up before gravity yanks it back down onto the tip of your " + clitDescript() + ".  The tip barely slips in, despite the slippery wetness of the faerie.   She screams, though in pleasure or pain you cannot be sure.  You reason that it must be pleasure, because the faerie is wiggling her hips and grabbing hold of the rest of your " + clitDescript() + ", straining to pull herself further down the fem-cock.  Her belly starts to distort, displaying the cylindrical bulge on her tummy, expanding and contracting slightly as each of your heart-beats works through your clit.\n\n");
-			outputText("In time, she manages to fully impale herself, quivering in orgasm as she gets off from the vibrations your pounding heart sends through your " + clitDescript() + ".  Her tongue lolls out and her eyes roll back, shut down by the extreme penetration, pain, and pleasure of the act.  You feel her cum soaking into you, sliding down into your slit and making your sensitive slit tingle.  Watching her get off is all it takes to bring you to orgasm with her, and the walls of your " + vaginaDescript(0) + " clamp down hungrily, contracting and gushing fluids over the faerie as she lies there, impaled on your crotch like a perverted ornament.\n\n");
+			outputText("In time, she manages to fully impale herself, quivering in orgasm as she gets off from the vibrations your pounding heart sends through your " + clitDescript() + ".  Her tongue lolls out, and her eyes roll back, shut down by the extreme penetration, pain, and pleasure of the act.  You feel her cum soaking into you, sliding down into your slit and making your sensitive slit tingle.  Watching her get off is all it takes to bring you to orgasm with her, and the walls of your " + vaginaDescript(0) + " clamp down hungrily, contracting and gushing fluids over the faerie as she lies there, impaled on your crotch like a perverted ornament.\n\n");
 		}
 		//(too big) (else – hump dat shit)
 		else {
-			outputText("Entranced by your swollen " + clitDescript() + ", the faerie watches it slowly erect, filling with blood like a smooth over-sensitive cock.  She tentatively touches it, gasping and pulling back when it twitches in response.   With a look of awe, she turns to you and says, \"<i>There's no way I could take this beautiful monster, but I know I can make it feel good!</i>\"\n\n");
+			outputText("Entranced by your swollen " + clitDescript() + ", the faerie watches it slowly erects, filling with blood like a smooth over-sensitive cock.  She tentatively touches it, gasping and pulling back when it twitches in response.   With a look of awe, she turns to you and says, \"<i>There's no way I could take this beautiful monster, but I know I can make it feel good!</i>\"\n\n");
 			outputText("She jumps onto it, making it bounce in the air as it takes her relatively insubstantial weight.  Embracing it in a full-body hug, she starts grinding on it, smearing her thick faerie juices into the clit and giggling every time you twitch from the feeling.  You squirm, sinking down from the raw sensation, your [legs] giving out underneath you.   Grabbing hold of a stump, you try to steady yourself, but the faerie humping your " + clitDescript() + " is interfering with your motor ability, and you slump into the forest loam, happily twitching as orgasm washes over you.\n\n");
 			outputText("Your " + clitDescript() + " jumps, throwing the tiny woman off.  She slips and scrabbles across the surface of your " + vaginaDescript(0) + ", sliding into your soaking gash.  She's squeezed tightly, sloshed around in the wetness of your orgasm.   The faerie's eyes cross, as she grows dizzy and battered in the sizzling whirlpool that is your groin.\n\n");
 		}
@@ -133,13 +138,13 @@ private function faerieRAEP():void {
 	//[OH SHIT ITS OVER, POOR BITCH CRAWLS OUT ALL STONE ON GIRLCUM]
 	//[FIRST TIME]
 	if(player.statusEffectv1(StatusEffects.FaerieFemFuck) == 1) {
-		outputText("Lying in the forest loam as you recover, you watch as the faerie stumbles out of your groin, holding her head and giggling nonstop.  She tries to put on a serious face but it's instantly overpowered by another fit of laughter, \"<i>Hehe, did you know I'd get stoned off your girlcum?  Omigod I've never been this -heheheheheh- high before!  Like I can see EVERYTHING.  Puuhleeeease don't make me do this again...</i>\"\n\n");
+		outputText("Lying in the forest loam as you recover, you watch as the faerie stumbles out of your groin, holding her head and giggling nonstop.  She tries to put on a serious face, but it's instantly overpowered by another fit of laughter, \"<i>Hehe, did you know I'd get stoned off your girlcum?  Omigod I've never been this -heheheheheh- high before!  Like I can see EVERYTHING.  Puuhleeeease don't make me do this again...</i>\"\n\n");
 		outputText("She flies off, hungry and looking for a flower to munch on.");
 	}
 	//[REPEAT LOW]
 	else if(player.statusEffectv1(StatusEffects.FaerieFemFuck) <= 5) {
 		outputText("The faerie slowly drags herself out of your " + vaginaDescript(0) + ", smiling broadly with her eyes dilated wide.  She slips off you, dropping to the ground and giggling, \"<i>Everything feels so soft.  Mmmm that was fun!</i>\"\n\n");
-		outputText("The little woman spins around happily, proclaiming, \"<i>The colors are like, so bright!  Oh gosh, I'm hungry!  See you and your clit later, just don't let me fall in your snatch, it fucks me up so much.  I don't think I can handle much more or I'll be crawling between your legs every chance I get!</i>\"\n\n");
+		outputText("The little woman spins around happily, proclaiming, \"<i>The colors are like, so bright!  Oh gosh, I'm hungry!  See you and your clit later, just don't let me fall in your snatch, it fucks me up so much.  I don't think I can handle much more, or I'll be crawling between your legs every chance I get!</i>\"\n\n");
 		outputText("She flits away, calling out, \"<i>Bye sweetie!</i>\"");
 	}
 	//[SLUTTIN IT UP]
@@ -155,53 +160,54 @@ private function faerieRAEP():void {
 private function faerieShooAway():void {
 	spriteSelect(SpriteDb.s_faerie);
 	clearOutput();
-	outputText("You shake your hands, shooing away the tiny faerie.  She's clearly been touched by the magics of this land and you want nothing to do with her. With a pouting look, she turns and buzzes away.");
+	outputText("You shake your hands, shooing away the tiny faerie.  She's clearly been touched by the magics of this land, and you want nothing to do with her. With a pouting look, she turns and buzzes away.");
 	doNext(camp.returnToCampUseOneHour);
 }
 
 private function faerieDoNothing():void {
+	var nippleOK:Boolean = player.nippleLength >= 1 && player.nippleLength <= 4.5;
+	var clitOK:Boolean = player.hasVagina() && player.clitLength >= 1.0 && player.clitLength <= 4.5;
+	var nippleSmall:Boolean = player.nippleLength < 1;
 	spriteSelect(SpriteDb.s_faerie);
 	clearOutput();
-	if(player.nippleLength >= 1) {
+	if(nippleOK && (!clitOK || rand(2) == 0)) {
 		outputText("She looks you over, stopping at your upper torso and letting out a cry of glee. She lands on your chest, her exposed pussy coming to rest on your nipple. With one hand she grabs hold of you above her head and uses her other hand to guide the rapidly hardening nub between her legs. She sighs in delight as her tight confines squeeze your nipple hard, the feeling somewhere between pinching fingers and suckling lips. You gasp in delight yourself, and you notice she can exercise amazing control with her groin muscles as a rippling feeling courses through your nipple.\n\n");
-		outputText("Your nipple starts to get sloppy and wet as if someone's tongue were around it, but it's really the faerie's love juices dribbling down, some running down your breast and some down her legs. She starts thrusting against you, and you notice her clit getting hard and pushing into your soft flesh. With a free hand you grab the area around your nipple and squeeze it harder, forcing more into her.\n\n");
+		outputText("Your nipple starts to get sloppy and wet as if someone's tongue were around it, but it's really the faerie's love juices dribbling down, some running down your breast, and some down her legs. She starts thrusting against you, and you notice her clit getting hard and pushing into your soft flesh. With a free hand you grab the area around your nipple and squeeze it harder, forcing more into her.\n\n");
 		if(player.biggestLactation() > 1) outputText("A squirt of milk shoots inside her, making the faerie moan. She looks up at you with lusty, slitted eyes, squeezing her legs together to draw more from you.\n\n");
-		outputText("Eventually you both find a rhythm and soon she's moaning loudly.  ");
+		outputText("Eventually you both find a rhythm, and soon she's moaning loudly.  ");
 		if(player.hasVagina()) outputText("With your other hand you start diddling your " + vaginaDescript(0) + ", adding your own soft moans to hers.  ");
-		outputText("A few blissful moments later, she shudders and you feel her uncontrolled spasms around your nipple.  ");
+		outputText("A few blissful moments later, she shudders, and you feel her uncontrolled spasms around your nipple.  ");
 		if(player.hasVagina()) outputText("You join her shortly after.  ");
 		outputText("The faerie goes limp and spirals to the ground, crashing gently and still twitching in the afterglow. Stepping back carefully, you leave her.");
 		if(player.biggestLactation() > 1.5) outputText("\n\nA copious gout of your milk escapes her rosy folds.");
 		player.orgasm();
 		dynStats("lib", -2);
 		doNext(camp.returnToCampUseOneHour);
-		return;
 	}
-	if (player.clitLength >= 1.0 && player.clitLength <= 4.5 && player.hasVagina() && rand(2) == 0) {
-		outputText("A smile crosses her face and she flutters down to your crotch. She starts by scissoring you despite the size difference, driving your clit into her despite its erect state. Compared to her, it looks massive. She swings one leg over it and starts impaling herself on it. Your taut clitoris barely fits inside her, and the tight confines on your sensitive nub are enough to make you weak in the knees. Staggering to the ground, you grab hold of her frail body in your fist and thrust her roughly on your engorged button. She wails in both pain and pleasure, being crushed and stretched open at once. Her cries of pain combined with the intense stimulation on your most sensitive part bring you to a quick orgasm.\n\n");
+	else if (clitOK) {
+		outputText("A smile crosses her face, and she flutters down to your crotch. She starts by scissoring you despite the size difference, driving your clit into her despite its erect state. Compared to her, it looks massive. She swings one leg over it and starts impaling herself on it. Your taut clitoris barely fits inside her, and the tight confines on your sensitive nub are enough to make you weak in the knees. Staggering to the ground, you grab hold of her frail body in your fist and thrust her roughly on your engorged button. She wails in both pain and pleasure, being crushed and stretched open at once. Her cries of pain combined with the intense stimulation on your most sensitive part bring you to a quick orgasm.\n\n");
 		if(player.vaginas[0].vaginalWetness >= VaginaClass.WETNESS_DROOLING) outputText("You drench the poor faerie completely in your female juices, soaking her hair and body. Overwhelmed and spent, you drop her to the ground and catch your breath. She licks up what's around her face, but is too weak to do anything else but lie in the dirt.\n\n");
-		else outputText("Shuddering, you maintain your composure and keep going, trying to ride the high for another. Eventually you look down and you can see the faerie's eyes have glazed over and rolled to the back of her head. Her cunt has started clamping down on you a lot harder, evidence of her state of near-constant orgasm. The random clenching brings you off again very quickly and you have an intense orgasm, joining your fae cohort.\n\n");
-		outputText("Time skips a beat and you eventually come down, gently relaxing your grip and disengaging the worn out faerie from your softening female parts. The faerie regains consciousness slowly and thanks you before flying off.");
+		else outputText("Shuddering, you maintain your composure and keep going, trying to ride the high for another. Eventually you look down, and you can see the faerie's eyes have glazed over and rolled to the back of her head. Her cunt has started clamping down on you a lot harder, evidence of her state of near-constant orgasm. The random clenching brings you off again very quickly, and you have an intense orgasm, joining your fae cohort.\n\n");
+		outputText("Time skips a beat, and you eventually come down, gently relaxing your grip and disengaging the worn out faerie from your softening female parts. The faerie regains consciousness slowly and thanks you before flying off.");
 		player.orgasm();
 		dynStats("lib", -1);
 		doNext(camp.returnToCampUseOneHour);
-		return;
 	}
-	if (player.clitLength > 4.5) {
-		outputText("The faerie flies close to your ear and speaks in a volume that would be a whisper from another human, \"You've got some sexy parts girl, but you're too big for me. I hope you find someone to get you off so I can watch.\" Then she flies in front of you, cutely kisses the bridge of your nose, and flies off.");
+	else if (nippleSmall) {
+		outputText("The faerie flies close to your nipple and sucks it gingerly.  You pant in pleasure as you feel it pucker tight in her mouth, tingling with her saliva.  She lets it pop free, swollen with arousal.  Her hand flicks it playfully, the sudden sensation fluttering through you as you close your eyes in pleasure.  You recover and find she has flown high into the trees, waving playfully as she escapes.\n\nYou frown and begin to dress yourself, flushing irritably as your nipples protrude further into your clothes than you remember.");
+		player.nippleLength += .25;
+		if(player.nippleLength > 3 || player.biggestTitSize() <= 2) {
+			outputText("  Thankfully it appears to be temporary.");
+			player.nippleLength -= .25;
+		}
+		dynStats("sen", 1, "lus", 5);
+		doNext(camp.returnToCampUseOneHour);
+	}
+	else {
+		outputText("The faerie flies close to your ear and speaks in a volume that would be a whisper from another human, \"You've got some sexy parts girl, but you're too big for me. I hope you find someone to get you off, so I can watch.\" Then she flies in front of you, cutely kisses the bridge of your nose, and flies off.");
 		dynStats("lus", 5);
 		doNext(camp.returnToCampUseOneHour);
-		return;
 	}
-	outputText("The faerie flies close to your nipple and sucks it gingerly.  You pant in pleasure as you feel it pucker tight in her mouth, tingling with her saliva.  She lets it pop free, swollen with arousal.  Her hand flicks it playfully, the sudden sensation fluttering through you as you close your eyes in pleasure.  You recover and find she has flown high into the trees, waving playfully as she escapes.\n\nYou frown and begin to dress yourself, flushing irritably as your nipples protrude further into your clothes than you remember.");
-	player.nippleLength += .25;
-	if(player.nippleLength > 3 || player.biggestTitSize() <= 2) {
-		outputText("  Thankfully it appears to be temporary.");
-		player.nippleLength -= .25;
-	}
-	dynStats("sen", 1, "lus", 5);
-	doNext(camp.returnToCampUseOneHour);
-	return;
 }
 
 //[No] *(let her go)
@@ -231,7 +237,7 @@ private function faerieCaptureHJ():void {
 		outputText("You hold her tightly and scold her, \"<i>If you don't like hard cocks, you shouldn't be dressed up like a such a slut, flying around and teasing me like that.  You should be ashamed of yourself.  Now you've got me all worked up - so you better make it up to me and take care of my little 'problem'</i>.\"\n\n");
 		outputText("She looks up at you and gulps before nodding silently, unwilling or unable to resist your command.   ");
 	}
-	outputText("You let her loose and she hovers in place, as if pondering her one last chance to escape.  She sighs and looks back up, blushing fiercely as she lands on your hip and gazes down at " + player.clothedOrNakedLower("the bulge of ") + "your groin.  You can't help but laugh as she " + player.clothedOrNakedLower("slips under your " + player.armorName, "climbs onto you") + ", crawling across your sensitive thigh towards your [cocks].\n\n");
+	outputText("You let her loose, and she hovers in place, as if pondering her one last chance to escape.  She sighs and looks back up, blushing fiercely as she lands on your hip and gazes down at " + player.clothedOrNakedLower("the bulge of ") + "your groin.  You can't help but laugh as she " + player.clothedOrNakedLower("slips under your " + player.armorName, "climbs onto you") + ", crawling across your sensitive thigh towards your [cocks].\n\n");
 	//Taurs get a special scene!
 	if(player.isTaur()) {
 		outputText("The tiny Faerie climbs on top of your " + cockDescript(0));
@@ -240,16 +246,16 @@ private function faerieCaptureHJ():void {
 		outputText("Your body begins to naturally jerk forward and backward, attempting to hump the mare that isn't there. You can feel the faerie sliding about until she clenches onto you tighter, which only serves to make you hump harder. Realizing her mistake too late, she attempts to loosen herself, but your wild bucking sends her flying forward.\n\n");
 		outputText("She smashes onto the end of your [cocks] and grasps at it. Her face crushes into your urethra as her tiny legs wrap themselves around the tip. Your wildly flailing cock starts to grow larger as your orgasm approaches, but the faerie doesn't notice as she happily drinks up your pre.\n\n");
 		//[No testicles:
-		if(player.balls == 0) outputText("Your tiny globules of semen go straight into her open mouth and she sucks them down gleefully before falling with a splat onto the pre soaked ground.\n\n");
+		if(player.balls == 0) outputText("Your tiny globules of semen go straight into her open mouth, and she sucks them down gleefully before falling with a splat onto the pre-soaked ground.\n\n");
 		else {
 			//[Small amount of cum:
-			if(player.cumQ() < 50) outputText("Your semen splashes straight into her face and she's quick to suck it up. She falls with a splat onto the pre soaked ground while your member drips periodic droplets of cum onto her head.\n\n");
+			if(player.cumQ() < 50) outputText("Your semen splashes straight into her face, and she's quick to suck it up. She falls with a splat onto the pre-soaked ground while your member drips periodic droplets of cum onto her head.\n\n");
 			//[Normal amount of cum:
-			else if(player.cumQ() < 200) outputText("Your semen washes into her face and she loses her grip on your [cocks]. She falls with a splat onto the pre soaked ground and you spray her with periodic spurts of fresh cum.\n\n");
+			else if(player.cumQ() < 200) outputText("Your semen washes into her face, and she loses her grip on your [cocks]. She falls with a splat onto the pre-soaked ground, and you spray her with periodic spurts of fresh cum.\n\n");
 			//[Huge amount of cum:
-			else outputText("Your semen collides with her face and she is propelled off of your cock onto the pre soaked ground. Your [balls] continue pumping out cum like a hose until she's almost swimming in it.\n\n");
+			else outputText("Your semen collides with her face, and she is propelled off of your cock onto the pre-soaked ground. Your [balls] continue pumping out cum like a hose until she's almost swimming in it.\n\n");
 		}
-		player.orgasm();
+		player.sexReward("Default", "Dick", true, false);
 		dynStats("lib", -.5);
 		//Epilogue!
 		if(player.statusEffectv1(StatusEffects.FaerieFucked) < 10) outputText("The faerie burps and giggles again before glaring up at you, accusing you with a mildly unfocused glare and asking, \"<i>Did you know we get drunk on cum?  Caushe I TRY SO HARRD not to get meshed up like this.</i>\"\n\n");
@@ -260,6 +266,7 @@ private function faerieCaptureHJ():void {
 	}
 	//Non-taurs
 	else {
+		sceneHunter.print("Check failed: Taur body.");
 		outputText("The faerie reaches your swollen member and ");
 		if(player.hasKnot(0)) outputText("climbs atop your knot, wrapping her legs around the narrower shaft to hold on.  You can feel her cheeks resting atop the 'bulb' of your canine anatomy, teasing you with feminine features you're far too large to penetrate.  ");
 		else if(player.cocks[0].cockType == CockTypesEnum.HORSE) outputText("climbs atop your [cock], hanging onto your ring of prepuce and wrapping her legs as far around your horse-like maleness as she can.  ");
@@ -267,7 +274,7 @@ private function faerieCaptureHJ():void {
 		else if(player.cocks[0].cockType == CockTypesEnum.TENTACLE) outputText("climbs onto your squirming [cock], wrapping her legs tightly around it as it wiggles and writhes with excitement.  Unbidden, it curls around and rubs its reddish-purple head against her face like an animal.  She gives it a gentle squeeze and licks it.  ");
 		else outputText("climbs on to your hardness, wrapping her legs tightly around it as she secures a perch against you.   You can feel her wet gash rubbing against your sensitive skin, teasing you with a tiny cunt you'll never be able to penetrate.  ");
 		outputText("Your internal muscles clench unconsciously, squeezing out a dollop of pre that rolls down into the faerie's hair, soaking her head and face.  You can't see her reaction, but you can feel it oozing between her body and you, lubricating her as she humps and rubs against you.  Tiny muffled moans escape " + player.clothedOrNakedLower("your [armor]", "her mouth") + ", indicating that some part of her is enjoying the task.\n\n");
-		outputText("Though she can only stimulate a few inches of you at a time, it feels really good – better than it should, and a budding warmth on the edge of release builds inside you.  " + player.clothedOrNakedLower("Too late you realize you should have gotten at least partially undressed.  You cum before you can do anything about it, splattering your [armor] with seed and leaving a wet patch on the crotch.  You can feel it dripping back onto you and the faerie as more spunk squirts out, soaking the tiny girl in spooge as the wet spot grows", "Good thing your junk is exposed as otherwise you would have ended up jizzing in your pants. You cum, splattering the faerie with seed. This continues until the tiny girl is soaked in spooge") + ".  ");
+		outputText("Though she can only stimulate a few inches of you at a time, it feels really good – better than it should, and a budding warmth on the edge of release builds inside you.  " + player.clothedOrNakedLower("Too late you realize you should have gotten at least partially undressed.  You cum before you can do anything about it, splattering your [armor] with seed and leaving a wet patch on the crotch.  You can feel it dripping back onto you, and the faerie as more spunk squirts out, soaking the tiny girl in spooge as the wet spot grows", "Good thing your junk is exposed as otherwise you would have ended up jizzing in your pants. You cum, splattering the faerie with seed. This continues until the tiny girl is soaked in spooge") + ".  ");
 		if(player.cumQ() > 250) {
 			outputText("You cum uncontrollably, " + player.clothedOrNakedLower("regretting your fertility as your body paints the inside of your [armor] with goopy whiteness.", "painting the ground with goopy whiteness.") + "  ");
 			if(player.cumQ() > 500) outputText("The proof of your release forms a puddle around you as your legs give out and y");
@@ -283,7 +290,7 @@ private function faerieCaptureHJ():void {
 		else outputText("The faerie burps and begins openly masturbating, panting and slurring happily, \"<i>Yush I-gasp-uh feel great!  MMMmmmhm, it makesh my twat so sensitive.  I'm gonna fly home and schtuff it full, then play with my clit till I fall ashleep!</i>\"\n\n");
 		if(player.statusEffectv1(StatusEffects.FaerieFucked) < 15) outputText("She licks her fingers and rolls around laughing, \"<i>Hehe, who caresh!  I'm happy! WHEEEEE!</i>\"\n\n");
 		outputText("The faerie takes off, still dripping, and flying in something less than a straight line...");
-		player.orgasm();
+		player.sexReward("Default", "Dick", true, false);
 		dynStats("lib", -.5);
 		if(!player.hasStatusEffect(StatusEffects.Jizzpants) && player.armor.name != "nothing" && player.armor != armors.LTHCARM && player.armor != armors.GOOARMR) player.createStatusEffect(StatusEffects.Jizzpants,1,0,0,0);
 		if (player.armor == armors.GOOARMR) {

--- a/classes/classes/Scenes/Areas/Forest/WaspGirl.as
+++ b/classes/classes/Scenes/Areas/Forest/WaspGirl.as
@@ -11,7 +11,6 @@ import classes.BodyParts.Hips;
 import classes.BodyParts.LowerBody;
 import classes.BodyParts.Tail;
 import classes.BodyParts.Wings;
-import classes.GlobalFlags.*;
 import classes.Scenes.SceneLib;
 import classes.StatusEffects.Combat.ParalyzeVenomDebuff;
 import classes.internals.ChainedDrop;
@@ -21,28 +20,17 @@ import classes.internals.ChainedDrop;
 		public function waspSpearAttack():void {
 			outputText("The " + short + " lunges at you, jabbing with her spear.  You dodge the first attack easily, ");
 			var evade:String = player.getEvasionReason();
-			if (evade == EVASION_EVADE) {
+			if (evade == EVASION_EVADE)
 				outputText("and you anticipate the upcoming spear strikes, dodging her attacks thanks to your incredible evasive ability!");
-				return;
-			}
-			else if (evade == EVASION_FLEXIBILITY) {
+			else if (evade == EVASION_FLEXIBILITY)
 				outputText("and you use your incredible flexibility to barely fold your body and avoid her attacks!");
-				return;
-			}
-			else if (evade == EVASION_MISDIRECTION) {
+			else if (evade == EVASION_MISDIRECTION)
 				outputText("and you use technique from Raphael to sidestep and completely avoid her barrage of attacks!");
-				return;
-			}
-			else if (evade == EVASION_SPEED || evade != null) {
+			else if (evade == EVASION_SPEED || evade != null)
 				outputText("and you successfully dodge her barrages of spear attacks!");
-				return;
-			}
-			else if (hasStatusEffect(StatusEffects.Blind) && rand(3) > 0) {
+			else if (hasStatusEffect(StatusEffects.Blind) && rand(3) > 0)
 					outputText("and step away as you watch the " + short + "'s blind attacks strike only air. ");
-					return;
-				}
-			else
-			{
+			else {
 				outputText("but she follows through with a spear strike, tearing into your " + (player.armor.name == "nothing" ? "" : "[armorName] and the underlying") + " flesh. ");
 				var paralyze:ParalyzeVenomDebuff = player.statusEffectByType(StatusEffects.ParalyzeVenom) as ParalyzeVenomDebuff;
 				if (paralyze) {

--- a/classes/classes/Scenes/Camp/CampScenes.as
+++ b/classes/classes/Scenes/Camp/CampScenes.as
@@ -275,6 +275,7 @@ public function HeavenTribulationThunderDoom():void {
 	EventParser.gameOver();
 }
 public function HclassHTintro():void {
+	spriteSelect(null);
 	outputText("\nAn expanse of ink-black clouds form from nowhere, engulfing the land in near-total darkness. You stand, looking up into the artificial night. You see a part of the clouds, directly above you, and from it, crimson lightning splits the sky, carving a trench in the ground in front of you. The unnatural lightning spreads, jagged webs across the black sky, the thunder roaring constantly in your ears. Your heart beats faster, your [skin] crawling with each crack.\n");
 	startCombat(new HclassHeavenTribulation());
 }
@@ -303,6 +304,7 @@ public function HclassHTsurvived():void {
 	cleanupAfterCombat();
 }
 public function GclassHTintro():void {
+	spriteSelect(null);
 	outputText("\nAn expanse of ink-black clouds form from nowhere, engulfing the land in near-total darkness. You stand, looking up into the artificial night. You see a part of the clouds, directly above you, and from it, crimson lightning splits the sky, carving a trench in the ground in front of you. The unnatural lightning spreads, jagged webs across the black sky, the thunder roaring constantly in your ears. Your heart beats faster, your [skin] crawling with each crack. The wind howls, and you break into a cold sweat. Your second tribulation starts now.\n");
 	startCombat(new GclassHeavenTribulation());
 }
@@ -342,6 +344,7 @@ public function GclassHTsurvived():void {
 	cleanupAfterCombat();
 }
 public function FclassHTintro():void {
+	spriteSelect(null);
 	outputText("\n An expanse of ink-black clouds form from nowhere, engulfing the land in near-total darkness. You stand, looking up into the artificial night. You see a part of the clouds, directly above you, and from it, crimson lightning splits the sky, carving a trench in the ground in front of you. The unnatural lightning spreads, jagged webs across the black sky, the thunder roaring constantly in your ears. Your heart beats faster, your [skin] crawling with each crack. The wind howls, and you break into a cold sweat. Your third tribulation starts now.\n");
 	startCombat(new FclassHeavenTribulation());
 }

--- a/classes/classes/Scenes/Combat/SpellsGrey/CorrosiveWaveSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/CorrosiveWaveSpell.as
@@ -43,7 +43,7 @@ public class CorrosiveWaveSpell extends AbstractGreySpell {
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
 		var baseDamage:Number = 2 * scalingBonusIntelligence(randomize);
-		if (player.hasPerk(PerkLib.Convergence) && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
+		if (player.hasPerk(PerkLib.Convergence) && monster != null && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
 			if (player.hasPerk(PerkLib.SuperConvergence)) {
 				if (monster.hasPerk(PerkLib.EnemyGroupType)) baseDamage *= 3.5;
 				else if (monster.hasPerk(PerkLib.EnemyLargeGroupType)) baseDamage *= 2;

--- a/classes/classes/Scenes/Combat/SpellsGrey/ShatterstoneSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/ShatterstoneSpell.as
@@ -53,7 +53,7 @@ public class ShatterstoneSpell extends AbstractGreySpell {
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
 		var baseDamage:Number = 2 * scalingBonusIntelligence(randomize);
-		if (player.hasPerk(PerkLib.Convergence) && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
+		if (player.hasPerk(PerkLib.Convergence) && monster != null && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
 			if (player.hasPerk(PerkLib.SuperConvergence)) {
 				if (monster.hasPerk(PerkLib.EnemyGroupType)) baseDamage *= 3.5;
 				else if (monster.hasPerk(PerkLib.EnemyLargeGroupType)) baseDamage *= 2;

--- a/classes/classes/Scenes/Combat/SpellsGrey/WaterSphereSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/WaterSphereSpell.as
@@ -43,7 +43,7 @@ public class WaterSphereSpell extends AbstractGreySpell {
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
 		var baseDamage:Number = 2 * scalingBonusIntelligence(randomize);
-		if (player.hasPerk(PerkLib.Convergence) && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
+		if (player.hasPerk(PerkLib.Convergence) && monster != null && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
 			if (player.hasPerk(PerkLib.SuperConvergence)) {
 				if (monster.hasPerk(PerkLib.EnemyGroupType)) baseDamage *= 3.5;
 				else if (monster.hasPerk(PerkLib.EnemyLargeGroupType)) baseDamage *= 2;

--- a/classes/classes/Scenes/Combat/SpellsGrey/WindBlastSpell.as
+++ b/classes/classes/Scenes/Combat/SpellsGrey/WindBlastSpell.as
@@ -43,7 +43,7 @@ public class WindBlastSpell extends AbstractGreySpell {
 	
 	public function calcDamage(monster:Monster, randomize:Boolean = true, casting:Boolean = true):Number { //casting - Increase Elemental Counter while casting (like Raging Inferno)
 		var baseDamage:Number = 2 * scalingBonusIntelligence(randomize);
-		if (player.hasPerk(PerkLib.Convergence) && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
+		if (player.hasPerk(PerkLib.Convergence) && monster != null && (monster.hasPerk(PerkLib.EnemyGroupType) || monster.hasPerk(PerkLib.EnemyLargeGroupType) || monster.hasPerk(PerkLib.Enemy300Type))) {
 			if (player.hasPerk(PerkLib.SuperConvergence)) {
 				if (monster.hasPerk(PerkLib.EnemyGroupType)) baseDamage *= 3.5;
 				else if (monster.hasPerk(PerkLib.EnemyLargeGroupType)) baseDamage *= 2;

--- a/classes/classes/Scenes/Dungeons/D3/D3.as
+++ b/classes/classes/Scenes/Dungeons/D3/D3.as
@@ -590,10 +590,8 @@ import classes.StatusEffects;
 			{
 				addButton(2, "Eggs", goToEggPile);
 			}
-			if (flags[kFLAGS.D3_DEMONIC_SCYTHE] == 0)
-			{
-				addButton(3, "Scythe", goToEggPile);
-			}
+			if (flags[kFLAGS.D3_DEMONIC_SCYTHE] == 0) addButton(3, "Scythe", takeScythe);
+			if (flags[kFLAGS.D3_GOBLIN_MECH_PRIME] == 0) addButton(4, "Mech", takeMech);
 			
 			return false;
 		}

--- a/classes/classes/Scenes/Soulforce.as
+++ b/classes/classes/Scenes/Soulforce.as
@@ -1734,7 +1734,7 @@ public class Soulforce extends BaseContent
 			addButton(11, "Midnight gossamer", AddGossa).hint("Add 1 Midnight Gossamer.");
 			addButton(12, consumables.VAMPBLD.shortName, addConsumable, consumables.VAMPBLD).hint("Add 1 " + consumables.VAMPBLD.longName + ".");
 			//addButton(11, "", ).hint("Add 1 .");
-			if (!player.hasPerk(PerkLib.ElementalConjurerMindAndBodySacrifice)) addButton(12, "E.Pearls", AddThePearls).hint("Add all three Elemental Pearls.");
+			addButton(12, "E.Pearls", AddThePearls).hint("Add all three Elemental Pearls.");
 			addButton(13, "-1-", NonEquipmentMenu, page - 1);
 			addButton(14, "Back", curry(SoulforceCheats1, 0));
 		}


### PR DESCRIPTION
Changes:
- SceneHunter: added checks/menus to Akbal, Faerie, Alraune. Akbal got a lot of stuff unlocked for herms, btw.
- Tentacles no longer fit any size. This should fix bugs when cock length and area are used explicitly and the 'fitting' tentacle was still considered too big (or vice versa)... (if anyone encountered the same scenes for Fit/Nofit in SceneHunter, this probably was the cause).
- Fixed broken Unicornum and Nocturnus spellpower bonus calculation.
- Fixed grey spell text in Abilities list.